### PR TITLE
Replace tonnage input with fixed hull size selector

### DIFF
--- a/starship-designer/src/components/ShipPanel.tsx
+++ b/starship-designer/src/components/ShipPanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Ship } from '../types/ship';
-import { TECH_LEVELS } from '../data/constants';
+import { TECH_LEVELS, HULL_SIZES } from '../data/constants';
 
 interface ShipPanelProps {
   ship: Ship;
@@ -41,16 +41,18 @@ const ShipPanel: React.FC<ShipPanelProps> = ({ ship, onUpdate }) => {
       </div>
 
       <div className="form-group">
-        <label htmlFor="tonnage">Tonnage *</label>
-        <input
+        <label htmlFor="tonnage">Hull Size *</label>
+        <select
           id="tonnage"
-          type="number"
-          min="100"
           value={ship.tonnage}
-          onChange={(e) => handleInputChange('tonnage', parseInt(e.target.value) || 100)}
-          placeholder="Minimum 100 tons"
-        />
-        <small>Minimum 100 tons</small>
+          onChange={(e) => handleInputChange('tonnage', parseInt(e.target.value))}
+        >
+          {HULL_SIZES.map(hull => (
+            <option key={hull.tonnage} value={hull.tonnage}>
+              {hull.tonnage} tons (Hull {hull.code}) - {hull.cost} MCr
+            </option>
+          ))}
+        </select>
       </div>
 
       <div className="form-group">
@@ -89,7 +91,7 @@ const ShipPanel: React.FC<ShipPanelProps> = ({ ship, onUpdate }) => {
             ✓ Tech level is required
           </li>
           <li className={ship.tonnage >= 100 ? 'valid' : 'invalid'}>
-            ✓ Tonnage must be at least 100
+            ✓ Hull size is required
           </li>
           <li className={ship.configuration ? 'valid' : 'invalid'}>
             ✓ Configuration is required

--- a/starship-designer/src/data/constants.ts
+++ b/starship-designer/src/data/constants.ts
@@ -1,5 +1,23 @@
 export const TECH_LEVELS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
 
+export const HULL_SIZES = [
+  { tonnage: 100, code: '1', cost: 2 },
+  { tonnage: 200, code: '2', cost: 8 },
+  { tonnage: 300, code: '3', cost: 12 },
+  { tonnage: 400, code: '4', cost: 16 },
+  { tonnage: 500, code: '5', cost: 32 },
+  { tonnage: 600, code: '6', cost: 48 },
+  { tonnage: 700, code: '7', cost: 64 },
+  { tonnage: 800, code: '8', cost: 80 },
+  { tonnage: 900, code: '9', cost: 90 },
+  { tonnage: 1000, code: 'A', cost: 100 },
+  { tonnage: 1200, code: 'C', cost: 120 },
+  { tonnage: 1400, code: 'E', cost: 140 },
+  { tonnage: 1600, code: 'G', cost: 160 },
+  { tonnage: 1800, code: 'J', cost: 180 },
+  { tonnage: 2000, code: 'L', cost: 200 }
+];
+
 export const WEAPON_TYPES = [
   { name: 'Pulse Laser Turret', mass: 2, cost: 1.5 },
   { name: 'Dual Pulse Laser Turret', mass: 2, cost: 2 },


### PR DESCRIPTION
- Add HULL_SIZES constant with 15 predefined hull sizes (100-2000 tons)
- Include hull codes (1, 2, 3, 4, 5, 6, 7, 8, 9, A, C, E, G, J, L) and costs (2-200 MCr)
- Update ShipPanel to use dropdown selector instead of number input
- Default to 100 ton Hull 1 (2 MCr)
- Keep tonnage numeric in database for calculations

🤖 Generated with [Claude Code](https://claude.ai/code)