### PR TITLE
Integrate fuel system with database and mass calculations

### DIFF
--- a/backend/server.ts
+++ b/backend/server.ts
@@ -33,7 +33,7 @@ async function initDatabase() {
 // Ship routes
 app.get('/api/ships', async (req, res) => {
   try {
-    const [rows] = await db.execute('SELECT id, name, tech_level, tonnage, configuration, description, created_at FROM ships ORDER BY created_at DESC');
+    const [rows] = await db.execute('SELECT id, name, tech_level, tonnage, configuration, fuel_weeks, description, created_at FROM ships ORDER BY created_at DESC');
     res.json(rows);
   } catch (error) {
     console.error('Error fetching ships:', error);
@@ -94,8 +94,8 @@ app.post('/api/ships', async (req, res) => {
     try {
       // Insert ship
       const [shipResult] = await db.execute(
-        'INSERT INTO ships (name, tech_level, tonnage, configuration, description) VALUES (?, ?, ?, ?, ?)',
-        [ship.name, ship.tech_level, ship.tonnage, ship.configuration, ship.description || null]
+        'INSERT INTO ships (name, tech_level, tonnage, configuration, fuel_weeks, description) VALUES (?, ?, ?, ?, ?, ?)',
+        [ship.name, ship.tech_level, ship.tonnage, ship.configuration, ship.fuel_weeks, ship.description || null]
       );
       
       const shipId = (shipResult as any).insertId;

--- a/starship-designer/src/components/EnginesPanel.tsx
+++ b/starship-designer/src/components/EnginesPanel.tsx
@@ -5,11 +5,12 @@ import { getAvailableEngines, calculateJumpFuel, calculateManeuverFuel, calculat
 interface EnginesPanelProps {
   engines: Engine[];
   shipTonnage: number;
+  fuelWeeks: number;
   onUpdate: (engines: Engine[]) => void;
+  onFuelWeeksUpdate: (weeks: number) => void;
 }
 
-const EnginesPanel: React.FC<EnginesPanelProps> = ({ engines, shipTonnage, onUpdate }) => {
-  const [fuelWeeks, setFuelWeeks] = useState(2);
+const EnginesPanel: React.FC<EnginesPanelProps> = ({ engines, shipTonnage, fuelWeeks, onUpdate, onFuelWeeksUpdate }) => {
 
   const getEngine = (type: Engine['engine_type']): Engine => {
     return engines.find(e => e.engine_type === type) || {
@@ -166,7 +167,7 @@ const EnginesPanel: React.FC<EnginesPanelProps> = ({ engines, shipTonnage, onUpd
           <select
             id="fuel-weeks"
             value={fuelWeeks}
-            onChange={(e) => setFuelWeeks(parseInt(e.target.value))}
+            onChange={(e) => onFuelWeeksUpdate(parseInt(e.target.value))}
           >
             {Array.from({length: effectiveMaxWeeks - 1}, (_, i) => i + 2).map(weeks => (
               <option key={weeks} value={weeks}>

--- a/starship-designer/src/components/SummaryPanel.tsx
+++ b/starship-designer/src/components/SummaryPanel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { ShipDesign, MassCalculation, CostCalculation, StaffRequirements } from '../types/ship';
+import { calculateTotalFuelMass } from '../data/constants';
 
 interface SummaryPanelProps {
   shipDesign: ShipDesign;
@@ -9,6 +10,13 @@ interface SummaryPanelProps {
 }
 
 const SummaryPanel: React.FC<SummaryPanelProps> = ({ shipDesign, mass, cost, staff }) => {
+  // Calculate fuel breakdown for display
+  const jumpDrive = shipDesign.engines.find(e => e.engine_type === 'jump_drive');
+  const maneuverDrive = shipDesign.engines.find(e => e.engine_type === 'maneuver_drive');
+  const jumpPerformance = jumpDrive?.performance || 0;
+  const maneuverPerformance = maneuverDrive?.performance || 0;
+  const totalFuelMass = calculateTotalFuelMass(shipDesign.ship.tonnage, jumpPerformance, maneuverPerformance, shipDesign.ship.fuel_weeks);
+
   return (
     <div className="panel-content">
       <h3>Ship Design Summary</h3>
@@ -18,6 +26,8 @@ const SummaryPanel: React.FC<SummaryPanelProps> = ({ shipDesign, mass, cost, sta
         <p><strong>Name:</strong> {shipDesign.ship.name}</p>
         <p><strong>Tech Level:</strong> {shipDesign.ship.tech_level}</p>
         <p><strong>Tonnage:</strong> {shipDesign.ship.tonnage} tons</p>
+        <p><strong>Configuration:</strong> {shipDesign.ship.configuration}</p>
+        <p><strong>Fuel Duration:</strong> {shipDesign.ship.fuel_weeks} weeks</p>
         {shipDesign.ship.description && (
           <p><strong>Description:</strong> {shipDesign.ship.description}</p>
         )}
@@ -27,6 +37,7 @@ const SummaryPanel: React.FC<SummaryPanelProps> = ({ shipDesign, mass, cost, sta
         <h4>Mass & Cost</h4>
         <p><strong>Total Mass:</strong> {mass.total} tons</p>
         <p><strong>Used Mass:</strong> {mass.used.toFixed(1)} tons</p>
+        <p><strong>Fuel Tank:</strong> {totalFuelMass.toFixed(1)} tons ({((totalFuelMass / mass.total) * 100).toFixed(1)}%)</p>
         <p><strong>Remaining Mass:</strong> {mass.remaining.toFixed(1)} tons</p>
         <p><strong>Total Cost:</strong> {Math.round(cost.total)} MCr</p>
         

--- a/starship-designer/src/types/ship.ts
+++ b/starship-designer/src/types/ship.ts
@@ -4,6 +4,7 @@ export interface Ship {
   tech_level: string;
   tonnage: number;
   configuration: 'standard' | 'streamlined' | 'distributed';
+  fuel_weeks: number;
   description?: string;
 }
 


### PR DESCRIPTION
- Add fuel_weeks field to Ship interface and database schema
- Update backend to store and retrieve fuel_weeks in ships table
- Pass fuel_weeks between components via props instead of local state
- Include fuel tank mass in total mass calculations
- Display fuel tank as separate line item in Summary panel
- Fuel mass now properly reduces remaining tonnage available
- Update App.tsx to initialize fuel_weeks default to 2 weeks

Database changes needed:
ALTER TABLE ships ADD COLUMN fuel_weeks INT NOT NULL DEFAULT 2;

Features:
- Fuel weeks persisted in database
- Fuel tank mass included in ship mass calculations
- Real-time fuel mass updates based on engine performance
- Fuel percentage of total ship mass shown in summary

🤖 Generated with [Claude Code](https://claude.ai/code)