### PR TITLE
Fix gunner calculation to exclude Hard Points from staffing requirements

### DIFF
--- a/starship-designer/src/App.tsx
+++ b/starship-designer/src/App.tsx
@@ -128,7 +128,9 @@ function App() {
     const engineers = Math.ceil(totalEnginesWeight / 100);
     
     // Gunners: 1 per weapon/turret mount
-    const weaponCount = shipDesign.weapons.reduce((sum, weapon) => sum + weapon.quantity, 0);
+    const weaponCount = shipDesign.weapons
+      .filter(weapon => weapon.weapon_name !== 'Hard Point')
+      .reduce((sum, weapon) => sum + weapon.quantity, 0);
     const defenseCount = shipDesign.defenses.filter(d => d.defense_type !== 'armor' && d.defense_type !== 'reflec')
       .reduce((sum, defense) => sum + defense.quantity, 0);
     const gunners = weaponCount + defenseCount;


### PR DESCRIPTION
- Hard Points do not require gunners to operate
- Filter out 'Hard Point' weapons from gunner count calculation
- Other weapons still require 1 gunner per weapon quantity
- Defense systems (except armor/reflec) still require gunners

Before: All weapons including Hard Points counted toward gunners
After: Only actual weapon systems count toward gunner requirements

🤖 Generated with [Claude Code](https://claude.ai/code)