### PR TITLE
Add comprehensive defense turret system with mount slot validation

### DIFF
--- a/starship-designer/src/App.tsx
+++ b/starship-designer/src/App.tsx
@@ -131,8 +131,7 @@ function App() {
     const weaponCount = shipDesign.weapons
       .filter(weapon => weapon.weapon_name !== 'Hard Point')
       .reduce((sum, weapon) => sum + weapon.quantity, 0);
-    const defenseCount = shipDesign.defenses.filter(d => d.defense_type !== 'armor' && d.defense_type !== 'reflec')
-      .reduce((sum, defense) => sum + defense.quantity, 0);
+    const defenseCount = shipDesign.defenses.reduce((sum, defense) => sum + defense.quantity, 0);
     const gunners = weaponCount + defenseCount;
     
     const subtotal = pilot + navigator + engineers + gunners;
@@ -212,7 +211,12 @@ function App() {
       case 3:
         return <WeaponsPanel weapons={shipDesign.weapons} shipTonnage={shipDesign.ship.tonnage} onUpdate={(weapons) => updateShipDesign({ weapons })} />;
       case 4:
-        return <DefensesPanel defenses={shipDesign.defenses} shipTonnage={shipDesign.ship.tonnage} onUpdate={(defenses) => updateShipDesign({ defenses })} />;
+        return <DefensesPanel 
+          defenses={shipDesign.defenses} 
+          shipTonnage={shipDesign.ship.tonnage} 
+          weaponsCount={shipDesign.weapons.reduce((sum, weapon) => sum + weapon.quantity, 0)}
+          onUpdate={(defenses) => updateShipDesign({ defenses })} 
+        />;
       case 5:
         return <BerthsPanel berths={shipDesign.berths} onUpdate={(berths) => updateShipDesign({ berths })} />;
       case 6:

--- a/starship-designer/src/components/DefensesPanel.tsx
+++ b/starship-designer/src/components/DefensesPanel.tsx
@@ -1,21 +1,125 @@
 import React from 'react';
 import type { Defense } from '../types/ship';
+import { DEFENSE_TYPES, getWeaponMountLimit } from '../data/constants';
 
 interface DefensesPanelProps {
   defenses: Defense[];
   shipTonnage: number;
+  weaponsCount: number;
   onUpdate: (defenses: Defense[]) => void;
 }
 
-const DefensesPanel: React.FC<DefensesPanelProps> = ({ defenses, shipTonnage, onUpdate }) => {
+const DefensesPanel: React.FC<DefensesPanelProps> = ({ defenses, shipTonnage, weaponsCount, onUpdate }) => {
+  const maxMountLimit = getWeaponMountLimit(shipTonnage);
+  const currentTurretCount = defenses.reduce((sum, defense) => sum + defense.quantity, 0);
+  const availableSlots = maxMountLimit - weaponsCount - currentTurretCount;
+
+  const addDefense = (defenseType: typeof DEFENSE_TYPES[0]) => {
+    if (availableSlots <= 0) return;
+    
+    const existingDefense = defenses.find(d => d.defense_type === defenseType.type);
+    if (existingDefense) {
+      const newDefenses = defenses.map(d =>
+        d.defense_type === defenseType.type
+          ? { ...d, quantity: d.quantity + 1, mass: defenseType.mass * (d.quantity + 1), cost: defenseType.cost * (d.quantity + 1) }
+          : d
+      );
+      onUpdate(newDefenses);
+    } else {
+      const newDefense: Defense = {
+        defense_type: defenseType.type as Defense['defense_type'],
+        quantity: 1,
+        mass: defenseType.mass,
+        cost: defenseType.cost
+      };
+      onUpdate([...defenses, newDefense]);
+    }
+  };
+
+  const removeDefense = (defenseType: string) => {
+    const newDefenses = defenses.map(d => {
+      if (d.defense_type === defenseType) {
+        if (d.quantity <= 1) {
+          return null;
+        }
+        return { ...d, quantity: d.quantity - 1, mass: d.mass - DEFENSE_TYPES.find(dt => dt.type === defenseType)!.mass, cost: d.cost - DEFENSE_TYPES.find(dt => dt.type === defenseType)!.cost };
+      }
+      return d;
+    }).filter(Boolean) as Defense[];
+    onUpdate(newDefenses);
+  };
+
   return (
     <div className="panel-content">
-      <p>Defense systems for your starship.</p>
-      <div className="form-group">
-        <label>Armor (tons)</label>
-        <input type="number" min="0" step="0.1" defaultValue="0" />
+      <p>Defense turrets for your starship. These use the same mount points as weapons.</p>
+      
+      <div className="mount-info">
+        <p><strong>Mount Usage:</strong> {weaponsCount + currentTurretCount} / {maxMountLimit} slots used</p>
+        <p><strong>Available Slots:</strong> {availableSlots}</p>
+        {availableSlots <= 0 && <p className="warning">⚠️ No available mount slots for additional turrets</p>}
       </div>
-      <p>More defense options coming soon...</p>
+
+      <div className="defense-selection">
+        <h3>Available Defense Turrets</h3>
+        {DEFENSE_TYPES.map(defenseType => {
+          const currentDefense = defenses.find(d => d.defense_type === defenseType.type);
+          const quantity = currentDefense?.quantity || 0;
+          
+          return (
+            <div key={defenseType.type} className="defense-item">
+              <div className="defense-info">
+                <strong>{defenseType.name}</strong>
+                <small>{defenseType.mass}t, {defenseType.cost}MCr each</small>
+              </div>
+              <div className="defense-controls">
+                <button 
+                  onClick={() => removeDefense(defenseType.type)}
+                  disabled={quantity === 0}
+                  className="remove-btn"
+                >
+                  -
+                </button>
+                <span className="quantity">{quantity}</span>
+                <button 
+                  onClick={() => addDefense(defenseType)}
+                  disabled={availableSlots <= 0}
+                  className="add-btn"
+                >
+                  +
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="defense-summary">
+        <h3>Defense Summary</h3>
+        {defenses.length === 0 ? (
+          <p>No defense turrets installed.</p>
+        ) : (
+          <table>
+            <thead>
+              <tr>
+                <th>Defense Type</th>
+                <th>Quantity</th>
+                <th>Mass (t)</th>
+                <th>Cost (MCr)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {defenses.map(defense => (
+                <tr key={defense.defense_type}>
+                  <td>{DEFENSE_TYPES.find(dt => dt.type === defense.defense_type)?.name || defense.defense_type}</td>
+                  <td>{defense.quantity}</td>
+                  <td>{defense.mass.toFixed(1)}</td>
+                  <td>{defense.cost.toFixed(1)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
     </div>
   );
 };

--- a/starship-designer/src/data/constants.ts
+++ b/starship-designer/src/data/constants.ts
@@ -378,10 +378,11 @@ export const WEAPON_TYPES = [
 ];
 
 export const DEFENSE_TYPES = [
-  { name: 'Point Defense Laser Turret', type: 'point_defense_laser', mass: 1, cost: 1 },
-  { name: 'Sand Caster Turret', type: 'sand_caster_single', mass: 1, cost: 1.3 },
-  { name: 'Dual Sand Caster Turret', type: 'sand_caster_dual', mass: 1, cost: 1.5 },
-  { name: 'Triple Sand Caster Turret', type: 'sand_caster_triple', mass: 1, cost: 1.8 }
+  { name: 'Sandcaster Turret', type: 'sandcaster_turret', mass: 1, cost: 1.3 },
+  { name: 'Dual Sandcaster Turret', type: 'dual_sandcaster_turret', mass: 1, cost: 1.5 },
+  { name: 'Triple Sandcaster Turret', type: 'triple_sandcaster_turret', mass: 1, cost: 1.8 },
+  { name: 'Point Defense Laser Turret', type: 'point_defense_laser_turret', mass: 1, cost: 1 },
+  { name: 'Dual Point Defense Laser Turret', type: 'dual_point_defense_laser_turret', mass: 1, cost: 1.5 }
 ];
 
 export const BERTH_TYPES = [

--- a/starship-designer/src/types/ship.ts
+++ b/starship-designer/src/types/ship.ts
@@ -35,7 +35,7 @@ export interface Weapon {
 
 export interface Defense {
   id?: number;
-  defense_type: 'armor' | 'point_defense_laser' | 'sand_caster_single' | 'sand_caster_dual' | 'sand_caster_triple' | 'reflec';
+  defense_type: 'sandcaster_turret' | 'dual_sandcaster_turret' | 'triple_sandcaster_turret' | 'point_defense_laser_turret' | 'dual_point_defense_laser_turret';
   mass: number;
   cost: number;
   quantity: number;


### PR DESCRIPTION
- Add 5 new defense turret types: Sandcaster variants and Point Defense Laser variants
- All turrets show mass (1t) and cost (1-1.8 MCr) in selection interface
- Defense turrets share mount slots with weapons (tonnage/100 limit)
- Combined slot validation prevents exceeding mount limits
- Interactive +/- controls for adding/removing turrets
- Real-time mount usage display with available slots
- Defense turrets require gunners (1 per turret)
- All defenses are optional (0+ allowed)

Defense Types:
- Sandcaster Turret (1t, 1.3 MCr)
- Dual Sandcaster Turret (1t, 1.5 MCr)
- Triple Sandcaster Turret (1t, 1.8 MCr)
- Point Defense Laser Turret (1t, 1 MCr)
- Dual Point Defense Laser Turret (1t, 1.5 MCr)

Mount System:
- 100t ship = 1 slot, 1200t ship = 12 slots
- Weapons + Defense turrets cannot exceed total slots
- Visual feedback when slots are full

🤖 Generated with [Claude Code](https://claude.ai/code)