### PR TITLE
Implement sand reload system for sandcaster defenses

### DIFF
--- a/backend/server.ts
+++ b/backend/server.ts
@@ -33,7 +33,7 @@ async function initDatabase() {
 // Ship routes
 app.get('/api/ships', async (req, res) => {
   try {
-    const [rows] = await db.execute('SELECT id, name, tech_level, tonnage, configuration, fuel_weeks, missile_reloads, description, created_at FROM ships ORDER BY created_at DESC');
+    const [rows] = await db.execute('SELECT id, name, tech_level, tonnage, configuration, fuel_weeks, missile_reloads, sand_reloads, description, created_at FROM ships ORDER BY created_at DESC');
     res.json(rows);
   } catch (error) {
     console.error('Error fetching ships:', error);
@@ -94,8 +94,8 @@ app.post('/api/ships', async (req, res) => {
     try {
       // Insert ship
       const [shipResult] = await db.execute(
-        'INSERT INTO ships (name, tech_level, tonnage, configuration, fuel_weeks, missile_reloads, description) VALUES (?, ?, ?, ?, ?, ?, ?)',
-        [ship.name, ship.tech_level, ship.tonnage, ship.configuration, ship.fuel_weeks, ship.missile_reloads || 0, ship.description || null]
+        'INSERT INTO ships (name, tech_level, tonnage, configuration, fuel_weeks, missile_reloads, sand_reloads, description) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+        [ship.name, ship.tech_level, ship.tonnage, ship.configuration, ship.fuel_weeks, ship.missile_reloads || 0, ship.sand_reloads || 0, ship.description || null]
       );
       
       const shipId = (shipResult as any).insertId;

--- a/starship-designer/src/App.tsx
+++ b/starship-designer/src/App.tsx
@@ -19,7 +19,7 @@ import './App.css';
 function App() {
   const [currentPanel, setCurrentPanel] = useState(0);
   const [shipDesign, setShipDesign] = useState<ShipDesign>({
-    ship: { name: '', tech_level: 'A', tonnage: 100, configuration: 'standard', fuel_weeks: 2, missile_reloads: 0, description: '' },
+    ship: { name: '', tech_level: 'A', tonnage: 100, configuration: 'standard', fuel_weeks: 2, missile_reloads: 0, sand_reloads: 0, description: '' },
     engines: [],
     fittings: [],
     weapons: [],
@@ -78,6 +78,9 @@ function App() {
     // Add missile reload mass
     used += shipDesign.ship.missile_reloads;
 
+    // Add sand reload mass
+    used += shipDesign.ship.sand_reloads;
+
     const total = shipDesign.ship.tonnage;
     const remaining = total - used;
     
@@ -121,6 +124,9 @@ function App() {
 
     // Add missile reload costs (1 MCr per ton)
     total += shipDesign.ship.missile_reloads;
+
+    // Add sand reload costs (0.1 MCr per ton)
+    total += shipDesign.ship.sand_reloads * 0.1;
 
     return { total };
   };
@@ -228,7 +234,10 @@ function App() {
           defenses={shipDesign.defenses} 
           shipTonnage={shipDesign.ship.tonnage} 
           weaponsCount={shipDesign.weapons.reduce((sum, weapon) => sum + weapon.quantity, 0)}
+          sandReloads={shipDesign.ship.sand_reloads}
+          remainingMass={mass.remaining + shipDesign.ship.sand_reloads}
           onUpdate={(defenses) => updateShipDesign({ defenses })} 
+          onSandReloadsUpdate={(sand_reloads) => updateShipDesign({ ship: { ...shipDesign.ship, sand_reloads } })}
         />;
       case 5:
         return <BerthsPanel berths={shipDesign.berths} onUpdate={(berths) => updateShipDesign({ berths })} />;

--- a/starship-designer/src/components/DefensesPanel.tsx
+++ b/starship-designer/src/components/DefensesPanel.tsx
@@ -6,13 +6,24 @@ interface DefensesPanelProps {
   defenses: Defense[];
   shipTonnage: number;
   weaponsCount: number;
+  sandReloads: number;
+  remainingMass: number;
   onUpdate: (defenses: Defense[]) => void;
+  onSandReloadsUpdate: (reloads: number) => void;
 }
 
-const DefensesPanel: React.FC<DefensesPanelProps> = ({ defenses, shipTonnage, weaponsCount, onUpdate }) => {
+const DefensesPanel: React.FC<DefensesPanelProps> = ({ defenses, shipTonnage, weaponsCount, sandReloads, remainingMass, onUpdate, onSandReloadsUpdate }) => {
   const maxMountLimit = getWeaponMountLimit(shipTonnage);
   const currentTurretCount = defenses.reduce((sum, defense) => sum + defense.quantity, 0);
   const availableSlots = maxMountLimit - weaponsCount - currentTurretCount;
+
+  // Check if any sandcaster turrets are installed
+  const hasSandcasters = defenses.some(defense => 
+    defense.defense_type.includes('sandcaster') && defense.quantity > 0
+  );
+  
+  // Calculate maximum sand reloads based on remaining mass
+  const maxSandReloads = Math.floor(remainingMass - sandReloads);
 
   const addDefense = (defenseType: typeof DEFENSE_TYPES[0]) => {
     if (availableSlots <= 0) return;
@@ -120,6 +131,35 @@ const DefensesPanel: React.FC<DefensesPanelProps> = ({ defenses, shipTonnage, we
           </table>
         )}
       </div>
+
+      {hasSandcasters && (
+        <div className="sand-reloads-section">
+          <h3>Sand Reloads</h3>
+          <p>Sandcaster turrets detected. You can allocate tonnage for sand reloads.</p>
+          <div className="form-group">
+            <label htmlFor="sand-reloads">Sand Reload Tonnage</label>
+            <input
+              id="sand-reloads"
+              type="number"
+              min="0"
+              max={maxSandReloads + sandReloads}
+              value={sandReloads}
+              onChange={(e) => onSandReloadsUpdate(Math.max(0, parseInt(e.target.value) || 0))}
+            />
+            <small>
+              0 - {maxSandReloads + sandReloads} tons available. 
+              Cost: {(sandReloads * 0.1).toFixed(1)} MCr (0.1 MCr per ton)
+            </small>
+          </div>
+          
+          {sandReloads > 0 && (
+            <div className="sand-summary">
+              <p><strong>Sand Reloads:</strong> {sandReloads} tons ({(sandReloads * 0.1).toFixed(1)} MCr)</p>
+              <p><small>Provides additional sand ammunition for sandcaster turrets</small></p>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/starship-designer/src/types/ship.ts
+++ b/starship-designer/src/types/ship.ts
@@ -6,6 +6,7 @@ export interface Ship {
   configuration: 'standard' | 'streamlined' | 'distributed';
   fuel_weeks: number;
   missile_reloads: number;
+  sand_reloads: number;
   description?: string;
 }
 


### PR DESCRIPTION
Added sand reload functionality that detects sandcaster turrets and allows tonnage allocation for sand reloads at 0.1 MCr per ton. Integrated with mass/cost calculations and database storage.

Features:
- Detects sandcaster, dual sandcaster, and triple sandcaster turrets
- Dynamic tonnage input (0 to remaining mass)
- Cost calculation at 0.1 MCr per ton
- Full API and database integration

🤖 Generated with [Claude Code](https://claude.ai/code)