### PR TITLE
Add Comms & Sensors options to Fittings panel

### DIFF
--- a/backend/server.ts
+++ b/backend/server.ts
@@ -114,8 +114,8 @@ app.post('/api/ships', async (req, res) => {
       if (fittings && fittings.length > 0) {
         for (const fitting of fittings) {
           await db.execute(
-            'INSERT INTO fittings (ship_id, fitting_type, mass, cost, launch_vehicle_mass) VALUES (?, ?, ?, ?, ?)',
-            [shipId, fitting.fitting_type, fitting.mass, fitting.cost, fitting.launch_vehicle_mass || null]
+            'INSERT INTO fittings (ship_id, fitting_type, mass, cost, launch_vehicle_mass, comms_sensors_type) VALUES (?, ?, ?, ?, ?, ?)',
+            [shipId, fitting.fitting_type, fitting.mass, fitting.cost, fitting.launch_vehicle_mass || null, fitting.comms_sensors_type || null]
           );
         }
       }

--- a/starship-designer/src/App.tsx
+++ b/starship-designer/src/App.tsx
@@ -21,7 +21,14 @@ function App() {
   const [shipDesign, setShipDesign] = useState<ShipDesign>({
     ship: { name: '', tech_level: 'A', tonnage: 100, configuration: 'standard', fuel_weeks: 2, missile_reloads: 0, sand_reloads: 0, description: '' },
     engines: [],
-    fittings: [],
+    fittings: [
+      {
+        fitting_type: 'comms_sensors',
+        comms_sensors_type: 'standard',
+        mass: 0,
+        cost: 0
+      }
+    ],
     weapons: [],
     defenses: [],
     berths: [],

--- a/starship-designer/src/components/FittingsPanel.tsx
+++ b/starship-designer/src/components/FittingsPanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Fitting } from '../types/ship';
-import { getBridgeMassAndCost } from '../data/constants';
+import { getBridgeMassAndCost, COMMS_SENSORS_TYPES } from '../data/constants';
 
 interface FittingsPanelProps {
   fittings: Fitting[];
@@ -12,6 +12,7 @@ const FittingsPanel: React.FC<FittingsPanelProps> = ({ fittings, shipTonnage, on
   const hasBridge = fittings.some(f => f.fitting_type === 'bridge');
   const hasHalfBridge = fittings.some(f => f.fitting_type === 'half_bridge');
   const launchTubes = fittings.filter(f => f.fitting_type === 'launch_tube');
+  const commsSensors = fittings.find(f => f.fitting_type === 'comms_sensors');
 
   const setBridgeType = (isHalfBridge: boolean) => {
     const { mass, cost } = getBridgeMassAndCost(shipTonnage, isHalfBridge);
@@ -58,6 +59,19 @@ const FittingsPanel: React.FC<FittingsPanelProps> = ({ fittings, shipTonnage, on
       const tubeIndex = fittings.slice(0, i + 1).filter(fit => fit.fitting_type === 'launch_tube').length - 1;
       return tubeIndex !== index;
     });
+    onUpdate(newFittings);
+  };
+
+  const setCommsSensorsType = (sensorType: typeof COMMS_SENSORS_TYPES[0]) => {
+    const newFittings = fittings.filter(f => f.fitting_type !== 'comms_sensors');
+    
+    newFittings.push({
+      fitting_type: 'comms_sensors',
+      comms_sensors_type: sensorType.type as any,
+      mass: sensorType.mass,
+      cost: sensorType.cost
+    });
+
     onUpdate(newFittings);
   };
 
@@ -118,6 +132,30 @@ const FittingsPanel: React.FC<FittingsPanelProps> = ({ fittings, shipTonnage, on
         <button onClick={addLaunchTube} className="add-btn">
           Add Launch Tube
         </button>
+      </div>
+
+      <div className="form-group">
+        <h3>Comms & Sensors</h3>
+        <p>Communications and sensor systems for the starship. Standard is included by default.</p>
+        
+        <div className="radio-group">
+          {COMMS_SENSORS_TYPES.map(sensorType => (
+            <label key={sensorType.type}>
+              <input
+                type="radio"
+                checked={commsSensors?.comms_sensors_type === sensorType.type || (!commsSensors && sensorType.type === 'standard')}
+                onChange={() => setCommsSensorsType(sensorType)}
+              />
+              {sensorType.name} ({sensorType.mass} tons, {sensorType.cost} MCr)
+            </label>
+          ))}
+        </div>
+        
+        {commsSensors && (
+          <div className="selected-summary">
+            <p><strong>Selected:</strong> {COMMS_SENSORS_TYPES.find(t => t.type === commsSensors.comms_sensors_type)?.name} - {commsSensors.mass} tons, {commsSensors.cost} MCr</p>
+          </div>
+        )}
       </div>
 
       <div className="validation-info">

--- a/starship-designer/src/data/constants.ts
+++ b/starship-designer/src/data/constants.ts
@@ -461,6 +461,14 @@ export function getBridgeMassAndCost(shipTonnage: number, isHalfBridge: boolean)
   return { mass: bridgeMass, cost: bridgeMass * 0.5 };
 }
 
+export const COMMS_SENSORS_TYPES = [
+  { name: 'Standard', type: 'standard', mass: 0, cost: 0 },
+  { name: 'Basic Civilian', type: 'basic_civilian', mass: 1, cost: 0.05 },
+  { name: 'Basic Military', type: 'basic_military', mass: 2, cost: 1 },
+  { name: 'Advanced', type: 'advanced', mass: 3, cost: 2 },
+  { name: 'Very Advanced', type: 'very_advanced', mass: 5, cost: 4 }
+];
+
 export function getWeaponMountLimit(shipTonnage: number): number {
   return Math.floor(shipTonnage / 100);
 }

--- a/starship-designer/src/types/ship.ts
+++ b/starship-designer/src/types/ship.ts
@@ -21,10 +21,11 @@ export interface Engine {
 
 export interface Fitting {
   id?: number;
-  fitting_type: 'bridge' | 'half_bridge' | 'launch_tube';
+  fitting_type: 'bridge' | 'half_bridge' | 'launch_tube' | 'comms_sensors';
   mass: number;
   cost: number;
   launch_vehicle_mass?: number;
+  comms_sensors_type?: 'standard' | 'basic_civilian' | 'basic_military' | 'advanced' | 'very_advanced';
 }
 
 export interface Weapon {


### PR DESCRIPTION
Added 5 communications and sensor system options to the Fittings panel:
- Standard (0 tons, 0 MCr) - Default and free
- Basic Civilian (1 ton, 0.05 MCr)
- Basic Military (2 tons, 1 MCr)
- Advanced (3 tons, 2 MCr)
- Very Advanced (5 tons, 4 MCr)

Features:
- Radio button selection with tons and cost display
- Standard option is default and selected automatically
- Integrated with mass/cost calculations and database storage
- Backend API support for comms_sensors_type field

🤖 Generated with [Claude Code](https://claude.ai/code)