### PR TITLE
Add comprehensive medical facilities system to Rec/Health panel

### DIFF
--- a/starship-designer/src/App.tsx
+++ b/starship-designer/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import type { ShipDesign, Ship, Engine, Fitting, Weapon, Defense, Berth, Facility, Cargo, Vehicle, Drone, MassCalculation, CostCalculation, StaffRequirements } from './types/ship';
-import { calculateTotalFuelMass, calculateVehicleServiceStaff } from './data/constants';
+import { calculateTotalFuelMass, calculateVehicleServiceStaff, calculateMedicalStaff } from './data/constants';
 import ShipPanel from './components/ShipPanel';
 import EnginesPanel from './components/EnginesPanel';
 import FittingsPanel from './components/FittingsPanel';
@@ -162,9 +162,15 @@ function App() {
       .reduce((sum, berth) => sum + berth.quantity, 0);
     const stewards = Math.ceil(totalStaterooms / 8);
     
-    const total = pilot + navigator + engineers + gunners + service + stewards;
+    // Medical staff: based on medical facilities
+    const medicalStaff = calculateMedicalStaff(shipDesign.facilities);
+    const nurses = medicalStaff.nurses;
+    const surgeons = medicalStaff.surgeons;
+    const techs = medicalStaff.techs;
     
-    return { pilot, navigator, engineers, gunners, service, stewards, total };
+    const total = pilot + navigator + engineers + gunners + service + stewards + nurses + surgeons + techs;
+    
+    return { pilot, navigator, engineers, gunners, service, stewards, nurses, surgeons, techs, total };
   };
 
   const isCurrentPanelValid = (): boolean => {

--- a/starship-designer/src/components/FacilitiesPanel.tsx
+++ b/starship-designer/src/components/FacilitiesPanel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { Facility } from '../types/ship';
+import { FACILITY_TYPES } from '../data/constants';
 
 interface FacilitiesPanelProps {
   facilities: Facility[];
@@ -20,6 +21,34 @@ const FacilitiesPanel: React.FC<FacilitiesPanelProps> = ({ facilities, onUpdate 
     }
   };
 
+  const addFacility = (facilityType: typeof FACILITY_TYPES[0]) => {
+    const existingFacility = facilities.find(f => f.facility_type === facilityType.type);
+    if (existingFacility) {
+      const newFacilities = facilities.map(f =>
+        f.facility_type === facilityType.type
+          ? { ...f, quantity: f.quantity + 1 }
+          : f
+      );
+      onUpdate(newFacilities);
+    } else {
+      onUpdate([...facilities, {
+        facility_type: facilityType.type as Facility['facility_type'],
+        quantity: 1,
+        mass: facilityType.mass,
+        cost: facilityType.cost
+      }]);
+    }
+  };
+
+  const removeFacility = (facilityType: string) => {
+    const newFacilities = facilities.map(f =>
+      f.facility_type === facilityType
+        ? { ...f, quantity: Math.max(0, f.quantity - 1) }
+        : f
+    ).filter(f => f.quantity > 0);
+    onUpdate(newFacilities);
+  };
+
   return (
     <div className="panel-content">
       <p>Recreation and health facilities. Commissary is required.</p>
@@ -27,6 +56,36 @@ const FacilitiesPanel: React.FC<FacilitiesPanelProps> = ({ facilities, onUpdate 
       {!hasCommissary && (
         <button onClick={addCommissary}>Add Required Commissary</button>
       )}
+      
+      <div className="component-list">
+        {FACILITY_TYPES.map(facilityType => {
+          const currentFacility = facilities.find(f => f.facility_type === facilityType.type);
+          const quantity = currentFacility?.quantity || 0;
+
+          return (
+            <div key={facilityType.type} className="component-item">
+              <div className="component-info">
+                <h4>{facilityType.name}</h4>
+                <p>Mass: {facilityType.mass} tons, Cost: {facilityType.cost} MCr</p>
+              </div>
+              <div className="quantity-control">
+                <button 
+                  onClick={() => removeFacility(facilityType.type)}
+                  disabled={quantity === 0}
+                >
+                  -
+                </button>
+                <span>{quantity}</span>
+                <button 
+                  onClick={() => addFacility(facilityType)}
+                >
+                  +
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
       
       <div className="validation-info">
         <h3>Requirements:</h3>
@@ -36,8 +95,6 @@ const FacilitiesPanel: React.FC<FacilitiesPanelProps> = ({ facilities, onUpdate 
           </li>
         </ul>
       </div>
-      
-      <p>More facilities coming soon...</p>
     </div>
   );
 };

--- a/starship-designer/src/components/StaffPanel.tsx
+++ b/starship-designer/src/components/StaffPanel.tsx
@@ -17,6 +17,9 @@ const StaffPanel: React.FC<StaffPanelProps> = ({ staffRequirements, berths }) =>
         <p>Gunners: {staffRequirements.gunners}</p>
         <p>Service (Vehicle Maintenance): {staffRequirements.service}</p>
         <p>Stewards: {staffRequirements.stewards}</p>
+        <p>Nurses: {staffRequirements.nurses}</p>
+        <p>Surgeons: {staffRequirements.surgeons}</p>
+        <p>Techs: {staffRequirements.techs}</p>
         <p><strong>Total Staff: {staffRequirements.total}</strong></p>
       </div>
       

--- a/starship-designer/src/data/constants.ts
+++ b/starship-designer/src/data/constants.ts
@@ -399,6 +399,10 @@ export const FACILITY_TYPES = [
   { name: 'Commissary', type: 'commissary', mass: 2, cost: 0.2, required: true },
   { name: 'Kitchens', type: 'kitchens', mass: 3, cost: 0.4 },
   { name: 'Officers Mess & Bar', type: 'officers_mess_bar', mass: 4, cost: 0.3 },
+  { name: 'First Aid Station', type: 'first_aid_station', mass: 0.5, cost: 0.1 },
+  { name: 'Autodoc', type: 'autodoc', mass: 1.5, cost: 0.05 },
+  { name: 'Med Bay', type: 'med_bay', mass: 4, cost: 2 },
+  { name: 'Surgical Ward', type: 'surgical_ward', mass: 8, cost: 8 },
   { name: 'Medical Bay', type: 'medical_bay', mass: 4, cost: 2 },
   { name: 'Surgical Bay', type: 'surgical_bay', mass: 5, cost: 8 },
   { name: 'Medical Garden', type: 'medical_garden', mass: 4, cost: 1 },
@@ -518,4 +522,22 @@ export function calculateVehicleServiceStaff(vehicles: { vehicle_type: string; q
   }
   
   return totalServiceStaff;
+}
+
+export function calculateMedicalStaff(facilities: { facility_type: string; quantity: number }[]): { nurses: number; surgeons: number; techs: number } {
+  let nurses = 0;
+  let surgeons = 0;
+  let techs = 0;
+  
+  for (const facility of facilities) {
+    if (facility.facility_type === 'med_bay') {
+      nurses += facility.quantity;
+    } else if (facility.facility_type === 'surgical_ward') {
+      surgeons += facility.quantity;
+      techs += facility.quantity;
+      nurses += facility.quantity;
+    }
+  }
+  
+  return { nurses, surgeons, techs };
 }

--- a/starship-designer/src/types/ship.ts
+++ b/starship-designer/src/types/ship.ts
@@ -54,7 +54,7 @@ export interface Berth {
 
 export interface Facility {
   id?: number;
-  facility_type: 'gym' | 'spa' | 'garden' | 'commissary' | 'kitchens' | 'officers_mess_bar' | 'medical_bay' | 'surgical_bay' | 'medical_garden' | 'library' | 'range' | 'club' | 'park' | 'shrine';
+  facility_type: 'gym' | 'spa' | 'garden' | 'commissary' | 'kitchens' | 'officers_mess_bar' | 'first_aid_station' | 'autodoc' | 'med_bay' | 'surgical_ward' | 'medical_bay' | 'surgical_bay' | 'medical_garden' | 'library' | 'range' | 'club' | 'park' | 'shrine';
   quantity: number;
   mass: number;
   cost: number;
@@ -90,6 +90,9 @@ export interface StaffRequirements {
   gunners: number;
   service: number;
   stewards: number;
+  nurses: number;
+  surgeons: number;
+  techs: number;
   total: number;
 }
 


### PR DESCRIPTION
- Add 4 new medical facility options: First Aid Station, Autodoc, Med Bay, Surgical Ward
- Implement medical staff requirements: Med Bay requires 1 Nurse, Surgical Ward requires 1 Surgeon + 1 Tech + 1 Nurse
- Update FacilitiesPanel with full facility selection interface including quantity controls
- Add medical staff calculation and display in StaffPanel
- Update type definitions to support new facility types and medical staff

🤖 Generated with [Claude Code](https://claude.ai/code)