### PR TITLE
Improve Engines panel layout with horizontal organization

### DIFF
--- a/starship-designer/src/App.css
+++ b/starship-designer/src/App.css
@@ -310,6 +310,20 @@
   font-weight: 600;
 }
 
+.ship-basic-info-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.ship-config-description-row {
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
 .engine-summary {
   margin-top: 2rem;
   background-color: #f8f9fa;
@@ -543,6 +557,16 @@
   }
   
   .fuel-horizontal-layout {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+  
+  .ship-basic-info-row {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+  
+  .ship-config-description-row {
     grid-template-columns: 1fr;
     gap: 1rem;
   }

--- a/starship-designer/src/App.css
+++ b/starship-designer/src/App.css
@@ -247,17 +247,67 @@
   color: #e74c3c;
 }
 
+.engines-horizontal-layout {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
 .engine-group {
   background-color: #f8f9fa;
   border: 1px solid #e9ecef;
   border-radius: 4px;
   padding: 1.5rem;
-  margin-bottom: 1.5rem;
+  margin-bottom: 0;
 }
 
 .engine-group h3 {
   margin: 0 0 1rem 0;
   color: #2c3e50;
+}
+
+.fuel-horizontal-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  align-items: start;
+}
+
+.fuel-selection {
+  background-color: #f8f9fa;
+  border: 1px solid #e9ecef;
+  border-radius: 4px;
+  padding: 1.5rem;
+}
+
+.fuel-summary {
+  background-color: #f8f9fa;
+  border: 1px solid #e9ecef;
+  border-radius: 4px;
+  padding: 1.5rem;
+}
+
+.fuel-summary h4 {
+  margin: 0 0 1rem 0;
+  color: #2c3e50;
+}
+
+.fuel-summary table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.fuel-summary th,
+.fuel-summary td {
+  padding: 0.5rem;
+  text-align: left;
+  border-bottom: 1px solid #dee2e6;
+}
+
+.fuel-summary .total-row {
+  border-top: 2px solid #2c3e50;
+  font-weight: 600;
 }
 
 .engine-summary {
@@ -486,5 +536,14 @@
   
   .summary-actions {
     flex-direction: column;
+  }
+  
+  .engines-horizontal-layout {
+    grid-template-columns: 1fr;
+  }
+  
+  .fuel-horizontal-layout {
+    grid-template-columns: 1fr;
+    gap: 1rem;
   }
 }

--- a/starship-designer/src/components/EnginesPanel.tsx
+++ b/starship-designer/src/components/EnginesPanel.tsx
@@ -83,31 +83,6 @@ const EnginesPanel: React.FC<EnginesPanelProps> = ({ engines, shipTonnage, fuelW
             )}
           </div>
 
-          {engine.drive_code && (
-            <>
-              <div className="form-group">
-                <label>Mass (tons)</label>
-                <input
-                  type="number"
-                  value={engine.mass}
-                  readOnly
-                  disabled
-                />
-                <small>Set by drive selection</small>
-              </div>
-
-              <div className="form-group">
-                <label>Cost (MCr)</label>
-                <input
-                  type="number"
-                  value={engine.cost}
-                  readOnly
-                  disabled
-                />
-                <small>Set by drive selection</small>
-              </div>
-            </>
-          )}
         </div>
         
         {engine.drive_code && (
@@ -156,49 +131,55 @@ const EnginesPanel: React.FC<EnginesPanelProps> = ({ engines, shipTonnage, fuelW
       <p>Configure the three required engine types for your starship.</p>
       <p><small><strong>Note:</strong> Jump and Maneuver drives require a Power Plant with equal or higher performance rating.</small></p>
       
-      {renderEngineInput('power_plant', 'Power Plant')}
-      {renderEngineInput('maneuver_drive', 'Maneuver Drive')}
-      {renderEngineInput('jump_drive', 'Jump Drive')}
+      <div className="engines-horizontal-layout">
+        {renderEngineInput('power_plant', 'Power Plant')}
+        {renderEngineInput('maneuver_drive', 'Maneuver Drive')}
+        {renderEngineInput('jump_drive', 'Jump Drive')}
+      </div>
 
       <div className="fuel-section">
         <h3>Fuel Requirements</h3>
-        <div className="form-group">
-          <label htmlFor="fuel-weeks">Maneuver Drive Fuel Duration</label>
-          <select
-            id="fuel-weeks"
-            value={fuelWeeks}
-            onChange={(e) => onFuelWeeksUpdate(parseInt(e.target.value))}
-          >
-            {Array.from({length: effectiveMaxWeeks - 1}, (_, i) => i + 2).map(weeks => (
-              <option key={weeks} value={weeks}>
-                {weeks} weeks
-              </option>
-            ))}
-          </select>
-          <small>Maximum {effectiveMaxWeeks} weeks based on available mass</small>
-        </div>
+        <div className="fuel-horizontal-layout">
+          <div className="fuel-selection">
+            <div className="form-group">
+              <label htmlFor="fuel-weeks">Maneuver Drive Fuel Duration</label>
+              <select
+                id="fuel-weeks"
+                value={fuelWeeks}
+                onChange={(e) => onFuelWeeksUpdate(parseInt(e.target.value))}
+              >
+                {Array.from({length: effectiveMaxWeeks - 1}, (_, i) => i + 2).map(weeks => (
+                  <option key={weeks} value={weeks}>
+                    {weeks} weeks
+                  </option>
+                ))}
+              </select>
+              <small>Maximum {effectiveMaxWeeks} weeks based on available mass</small>
+            </div>
+          </div>
 
-        <div className="fuel-summary">
-          <h4>Fuel Mass Breakdown:</h4>
-          <table>
-            <tbody>
-              <tr>
-                <td>Jump Fuel (per jump):</td>
-                <td>{jumpFuel.toFixed(1)} tons</td>
-                <td><small>({jumpDrive.performance > 0 ? `J-${jumpDrive.performance}` : 'No Jump Drive'} × 0.1 × {shipTonnage}t)</small></td>
-              </tr>
-              <tr>
-                <td>Maneuver Fuel ({fuelWeeks} weeks):</td>
-                <td>{maneuverFuel.toFixed(1)} tons</td>
-                <td><small>({maneuverDrive.performance > 0 ? `M-${maneuverDrive.performance}` : 'No Maneuver Drive'} × 0.01 × {shipTonnage}t × {fuelWeeks/2})</small></td>
-              </tr>
-              <tr className="total-row">
-                <td><strong>Total Fuel Mass:</strong></td>
-                <td><strong>{totalFuelMass.toFixed(1)} tons</strong></td>
-                <td><small>{((totalFuelMass / shipTonnage) * 100).toFixed(1)}% of ship mass</small></td>
-              </tr>
-            </tbody>
-          </table>
+          <div className="fuel-summary">
+            <h4>Fuel Mass Breakdown:</h4>
+            <table>
+              <tbody>
+                <tr>
+                  <td>Jump Fuel (per jump):</td>
+                  <td>{jumpFuel.toFixed(1)} tons</td>
+                  <td><small>({jumpDrive.performance > 0 ? `J-${jumpDrive.performance}` : 'No Jump Drive'} × 0.1 × {shipTonnage}t)</small></td>
+                </tr>
+                <tr>
+                  <td>Maneuver Fuel ({fuelWeeks} weeks):</td>
+                  <td>{maneuverFuel.toFixed(1)} tons</td>
+                  <td><small>({maneuverDrive.performance > 0 ? `M-${maneuverDrive.performance}` : 'No Maneuver Drive'} × 0.01 × {shipTonnage}t × {fuelWeeks/2})</small></td>
+                </tr>
+                <tr className="total-row">
+                  <td><strong>Total Fuel Mass:</strong></td>
+                  <td><strong>{totalFuelMass.toFixed(1)} tons</strong></td>
+                  <td><small>{((totalFuelMass / shipTonnage) * 100).toFixed(1)}% of ship mass</small></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
         </div>
       </div>
 

--- a/starship-designer/src/components/FacilitiesPanel.tsx
+++ b/starship-designer/src/components/FacilitiesPanel.tsx
@@ -65,12 +65,7 @@ const FacilitiesPanel: React.FC<FacilitiesPanelProps> = ({ facilities, onUpdate 
           return (
             <div key={facilityType.type} className="component-item">
               <div className="component-info">
-<<<<<<< HEAD
                 <h4>{facilityType.name}, {facilityType.mass} tons, {facilityType.cost} MCr</h4>
-=======
-                <h4>{facilityType.name}</h4>
-                <p>Mass: {facilityType.mass} tons, Cost: {facilityType.cost} MCr</p>
->>>>>>> main
               </div>
               <div className="quantity-control">
                 <button 

--- a/starship-designer/src/components/ShipPanel.tsx
+++ b/starship-designer/src/components/ShipPanel.tsx
@@ -14,71 +14,75 @@ const ShipPanel: React.FC<ShipPanelProps> = ({ ship, onUpdate }) => {
 
   return (
     <div className="panel-content">
-      <div className="form-group">
-        <label htmlFor="ship-name">Ship Name *</label>
-        <input
-          id="ship-name"
-          type="text"
-          maxLength={32}
-          value={ship.name}
-          onChange={(e) => handleInputChange('name', e.target.value)}
-          placeholder="Enter ship name (max 32 characters)"
-        />
-        <small>{ship.name.length}/32 characters</small>
+      <div className="ship-basic-info-row">
+        <div className="form-group">
+          <label htmlFor="ship-name">Ship Name *</label>
+          <input
+            id="ship-name"
+            type="text"
+            maxLength={32}
+            value={ship.name}
+            onChange={(e) => handleInputChange('name', e.target.value)}
+            placeholder="Enter ship name (max 32 characters)"
+          />
+          <small>{ship.name.length}/32 characters</small>
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="tonnage">Hull Size *</label>
+          <select
+            id="tonnage"
+            value={ship.tonnage}
+            onChange={(e) => handleInputChange('tonnage', parseInt(e.target.value))}
+          >
+            {HULL_SIZES.map(hull => (
+              <option key={hull.tonnage} value={hull.tonnage}>
+                {hull.tonnage} tons (Hull {hull.code}) - {hull.cost} MCr
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="tech-level">Tech Level *</label>
+          <select
+            id="tech-level"
+            value={ship.tech_level}
+            onChange={(e) => handleInputChange('tech_level', e.target.value)}
+          >
+            {TECH_LEVELS.map(level => (
+              <option key={level} value={level}>{level}</option>
+            ))}
+          </select>
+        </div>
       </div>
 
-      <div className="form-group">
-        <label htmlFor="tech-level">Tech Level *</label>
-        <select
-          id="tech-level"
-          value={ship.tech_level}
-          onChange={(e) => handleInputChange('tech_level', e.target.value)}
-        >
-          {TECH_LEVELS.map(level => (
-            <option key={level} value={level}>{level}</option>
-          ))}
-        </select>
-      </div>
+      <div className="ship-config-description-row">
+        <div className="form-group">
+          <label htmlFor="configuration">Configuration *</label>
+          <select
+            id="configuration"
+            value={ship.configuration}
+            onChange={(e) => handleInputChange('configuration', e.target.value)}
+          >
+            <option value="standard">Standard (wedge, cone, sphere or cylinder)</option>
+            <option value="streamlined">Streamlined (wing, disc or lifting body for atmospheric entry)</option>
+            <option value="distributed">Distributed (multiple sections, atmosphere/gravity incompatible)</option>
+          </select>
+        </div>
 
-      <div className="form-group">
-        <label htmlFor="tonnage">Hull Size *</label>
-        <select
-          id="tonnage"
-          value={ship.tonnage}
-          onChange={(e) => handleInputChange('tonnage', parseInt(e.target.value))}
-        >
-          {HULL_SIZES.map(hull => (
-            <option key={hull.tonnage} value={hull.tonnage}>
-              {hull.tonnage} tons (Hull {hull.code}) - {hull.cost} MCr
-            </option>
-          ))}
-        </select>
-      </div>
-
-      <div className="form-group">
-        <label htmlFor="configuration">Configuration *</label>
-        <select
-          id="configuration"
-          value={ship.configuration}
-          onChange={(e) => handleInputChange('configuration', e.target.value)}
-        >
-          <option value="standard">Standard (wedge, cone, sphere or cylinder)</option>
-          <option value="streamlined">Streamlined (wing, disc or lifting body for atmospheric entry)</option>
-          <option value="distributed">Distributed (multiple sections, atmosphere/gravity incompatible)</option>
-        </select>
-      </div>
-
-      <div className="form-group">
-        <label htmlFor="description">Description (Optional)</label>
-        <textarea
-          id="description"
-          maxLength={250}
-          value={ship.description || ''}
-          onChange={(e) => handleInputChange('description', e.target.value)}
-          placeholder="Enter ship description (max 250 characters)"
-          rows={4}
-        />
-        <small>{(ship.description || '').length}/250 characters</small>
+        <div className="form-group">
+          <label htmlFor="description">Description (Optional)</label>
+          <textarea
+            id="description"
+            maxLength={250}
+            value={ship.description || ''}
+            onChange={(e) => handleInputChange('description', e.target.value)}
+            placeholder="Enter ship description (max 250 characters)"
+            rows={4}
+          />
+          <small>{(ship.description || '').length}/250 characters</small>
+        </div>
       </div>
 
       <div className="validation-info">


### PR DESCRIPTION
- Remove redundant mass/cost input fields from engine selections (already shown in dropdown labels)
- Arrange all 3 engine selections on single horizontal line using CSS Grid
- Split fuel section into horizontal layout: fuel selector on left, breakdown table on right
- Add responsive design for mobile devices (stacks vertically)
- Improve space efficiency and visual organization of engines configuration

🤖 Generated with [Claude Code](https://claude.ai/code)