### PR TITLE
Extend megastructure max tonnage to 1,000,000,000 tons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is the **Traveller Megastructure Designer** - a React-based web application for designing megastructures (1,000,000–100,000,000 tons, in 1M-ton steps) based on the Traveller SRD (System Reference Document) spacecraft design rules. The application uses IndexedDB for local persistence and features a multi-panel wizard interface for configuring all aspects of a megastructure.
+This is the **Traveller Megastructure Designer** - a React-based web application for designing megastructures (1,000,000–1,000,000,000 tons, in 1M-ton steps) based on the Traveller SRD (System Reference Document) spacecraft design rules. The application uses IndexedDB for local persistence and features a multi-panel wizard interface for configuring all aspects of a megastructure.
 
 **Megastructures have no jump drives.** They are permanent (or very-slow-moving) structures — ring worlds, orbital habitats, shipyards. This is a hard rule difference from the sibling `main` (100–2,000 ton starships) and `capital` (2,000–1,000,000 ton capital ships) branches, which do have jump drives. Don't port jump-drive logic back in from those branches.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Megastructure Designer for the Traveller RPG, built with Claude. Uses a Wizard UI and IndexedDB for browser-local persistence — no backend server required.
 
-Megastructures are permanent (or near-stationary) constructions from 1,000,000 to 100,000,000 tons (in 1,000,000-ton steps) — ring worlds, orbital habitats, shipyards, and similar. Unlike the sibling Starship and Capital Ship designers in this repository, megastructures have **no jump drive**.
+Megastructures are permanent (or near-stationary) constructions from 1,000,000 to 1,000,000,000 tons (in 1,000,000-ton steps) — ring worlds, orbital habitats, shipyards, and similar. Unlike the sibling Starship and Capital Ship designers in this repository, megastructures have **no jump drive**.
 
 ## Quick Start
 
@@ -16,7 +16,7 @@ The application will be available at `http://localhost:5173`.
 ## Features
 
 - **Multi-Panel Design Interface**: 15 panels for complete megastructure configuration
-- **Megastructure Scale**: Designs from 1,000,000 to 100,000,000 tons, with a control center, sensors, and computer that scale by the number of million-ton sections
+- **Megastructure Scale**: Designs from 1,000,000 to 1,000,000,000 tons, with a control center, sensors, and computer that scale by the number of million-ton sections
 - **Power Plant & Maneuver Drive**: No jump drive; power plant performance is tech-level gated (up to P-12 at TL-J) so an Antimatter Plant (which needs P-10+) is reachable
 - **Antimatter Plants**: Cut maneuver fuel requirements to 1/10th once installed
 - **Zone Sections**: Residential, commercial, industrial, farm, park, and other 1,000-ton zone types

--- a/src/data/constants.test.ts
+++ b/src/data/constants.test.ts
@@ -271,8 +271,24 @@ describe('getScreenSpecs', () => {
     expect(getScreenSpecs('meson_screen', 25_000_000)).toEqual({ mass: 120, cost: 140 });
     expect(getScreenSpecs('black_globe', 25_000_000)).toEqual({ mass: 45, cost: 450 });
 
-    // Max megastructure tonnage (100,000,000) is still within this tier
-    expect(getScreenSpecs('nuclear_damper', 100_000_000)).toEqual({ mass: 120, cost: 100 });
+    expect(getScreenSpecs('nuclear_damper', 124_999_999)).toEqual({ mass: 120, cost: 100 });
+  });
+
+  it('adds three tier increments for the 125,000,000-624,999,999 ton tier', () => {
+    expect(getScreenSpecs('nuclear_damper', 125_000_000)).toEqual({ mass: 140, cost: 110 });
+    expect(getScreenSpecs('meson_screen', 125_000_000)).toEqual({ mass: 130, cost: 150 });
+    expect(getScreenSpecs('black_globe', 125_000_000)).toEqual({ mass: 50, cost: 500 });
+
+    expect(getScreenSpecs('nuclear_damper', 624_999_999)).toEqual({ mass: 140, cost: 110 });
+  });
+
+  it('adds four tier increments for the 625,000,000+ ton tier (covers the 1B max)', () => {
+    expect(getScreenSpecs('nuclear_damper', 625_000_000)).toEqual({ mass: 160, cost: 120 });
+    expect(getScreenSpecs('meson_screen', 625_000_000)).toEqual({ mass: 140, cost: 160 });
+    expect(getScreenSpecs('black_globe', 625_000_000)).toEqual({ mass: 55, cost: 550 });
+
+    // Max megastructure tonnage (1,000,000,000) is still within this tier
+    expect(getScreenSpecs('nuclear_damper', 1_000_000_000)).toEqual({ mass: 160, cost: 120 });
   });
 
   it('returns null below the minimum megastructure tonnage', () => {

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -466,8 +466,8 @@ export function calculateDroneServiceStaff(drones: { drone_type: string; quantit
 
 // ── Megastructure helpers ────────────────────────────────────────────────────
 
-// Hull sizes for megastructures: 1M–100M tons in 1M-ton steps
-export const MEGASTRUCTURE_HULL_SIZES = Array.from({ length: 100 }, (_, i) => {
+// Hull sizes for megastructures: 1M–1B tons in 1M-ton steps
+export const MEGASTRUCTURE_HULL_SIZES = Array.from({ length: 1000 }, (_, i) => {
   const tonnage = (i + 1) * 1_000_000;
   return { tonnage, code: `${i + 1}M`, cost: tonnage / 10 };
 });


### PR DESCRIPTION
## Summary
- `MEGASTRUCTURE_HULL_SIZES` now generates 1,000 entries (1M–1B tons in 1M-ton steps) instead of 100 (1M–100M).
- Checked defensive screen scaling for the new range as requested: `getScreenSpecs()`/`getScreenTonnageTier()` compute the tier as a formula (tonnage bracket = `1,000,000 * 5^tier`), not a hardcoded per-tier table, so **no code change was needed there**. The extended range does newly reach two more 5x tier boundaries that were unreachable at the old 100M cap — 125,000,000 and 625,000,000 (the new 1B max falls in the tier-4 bracket, 625,000,000–3,124,999,999). Added test coverage for both new tiers, and fixed a test comment that called 100,000,000 the max tonnage (no longer true).
- Updated the max-tonnage figure in `CLAUDE.md` and `README.md`.

## Test plan
- [x] `pnpm test:run` — 180/180 tests passing
- [x] `pnpm lint` — 0 errors, 0 warnings
- [x] `pnpm build` — clean production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXHBvdJ5mLZTWFRChrvkoU