### PR TITLE
Pin wrangler-action to Wrangler 4

### DIFF
--- a/.github/workflows/deploy-shipdesign.yml
+++ b/.github/workflows/deploy-shipdesign.yml
@@ -25,3 +25,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4"


### PR DESCRIPTION
## Summary
- Every push-to-main deploy has been failing since the deploy workflow was added: wrangler-action@v3 defaults to a cached Wrangler 3.90.0, which errors on our wrangler.jsonc ("Missing entry-point").
- Pins \`wranglerVersion: "4"\` so it installs a Wrangler 4.x that understands the config.

## Test plan
- [ ] Merge and confirm the Action succeeds and redeploys ShipDesign