### PR TITLE
Add Robotics rule: TL-F+ per-engine crew reduction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,7 +268,7 @@ const calcFM = (t, p, w, a) => { ... };
 - `cleanupScreensForTechLevel()`: clamp screen quantity down to the new `getMaxScreens()` ceiling (drop if it hits 0)
 - Called from `App.tsx`'s `updateShipDesign()` whenever `ship.tech_level` actually changes
 
-**`src/utils/crewCalculations.ts`**: Pilot/navigator crew-size formulas (see Staff Requirements Logic)
+**`src/utils/crewCalculations.ts`**: Pilot/navigator/engineer crew-size formulas (see Staff Requirements Logic)
 
 **`src/utils/csv.ts`**: `escapeCsvField()` — quotes/escapes a CSV field if it contains a comma, quote, or newline (ship names and generated item labels routinely do)
 
@@ -308,7 +308,7 @@ The `calculateMass()` function in App.tsx handles:
 Crew calculation in `calculateStaffRequirements()` (hoisted before JSX return in App.tsx, called once per render):
 - **Pilot**: `calculatePilotCount(maneuverPerformance)` — 8 pilots (24x7 coverage with spares) if the maneuver drive is M-1 or better; 1 (skeleton crew) if the structure is stationary (M-0 / no maneuver drive)
 - **Navigator**: `calculateNavigatorCount(ship.atmosphere_support)` — 0 by default (a plotted course is followed for decades, no standing navigator needed); 4 if `atmosphere_support` is set (a floating-city-style structure needs active navigation), toggled on the Megastructure panel (`ShipPanel.tsx`)
-- **Engineers**: at least 1 per engine (`max(engineCount, 1)`), plus `ceil(mass/100) - 1` extra for each engine whose mass exceeds 100 tons
+- **Engineers** (`calculateEngineerCount()` in `src/utils/crewCalculations.ts`): at least 1 per engine (minimum 1 total, even with none configured), plus `ceil(mass/100) - 1` extra for each engine whose mass exceeds 100 tons. If the Robotics rule is enabled (TL-F+, toggled via the Rules menu), each engine's own crew requirement is divided (rounded up, per engine) by `getRoboticsCrewDivisor(techLevel)`: TL-F=1/2, TL-G=1/4, TL-H=1/6, TL-J=1/8
 - **Gunners**:
   - 1 per 10 turrets/barbettes (rounded up)
   - 1 per 10 defense turrets (rounded up)
@@ -335,13 +335,14 @@ Use helper functions: `isTechLevelAtLeast()`, `getMaxPowerPlantByTechLevel()`, `
 
 ### Rules System
 
-`activeRules` state (Set<string>) is passed down to several components (`RulesMenu`, `EnginesPanel`, `MassSidebar`, `SummaryPanel`, `printContent.ts`), but **as of this branch, nothing actually reads `activeRules.has(...)`** — it's plumbing inherited from the `capital` branch that isn't wired to any calculation here. The real mechanics it used to gate are now driven directly by game state instead:
+`activeRules` state (Set<string>) is passed down to several components (`RulesMenu`, `EnginesPanel`, `MassSidebar`, `SummaryPanel`, `printContent.ts`). Most of it is still inert plumbing inherited from the `capital` branch, but `'robotics'` is a real exception — App.tsx's `calculateStaffRequirements()` reads `activeRules.has('robotics')` directly to drive the engineer-count reduction:
 - Antimatter fuel discount: driven by `hasAntimatterPlant(shipDesign.fuel_systems)`, not by toggling the "Antimatter" rule
 - `'spacecraft_design_srd'`: always enabled, can't be disabled (display-only)
 - `'high_guard_capital_ships'`: always shown disabled (display-only, not applicable to megastructures)
 - `'antimatter'`: toggleable in the UI (gated to TL-H+ ships) but currently has no effect on any calculation
+- `'robotics'`: toggleable in the UI (gated to TL-F+ ships) and **does** affect calculations — `calculateEngineerCount()` (`src/utils/crewCalculations.ts`) divides each engine's crew requirement (rounded up) by `getRoboticsCrewDivisor(techLevel)` when enabled: TL-F=1/2, TL-G=1/4, TL-H=1/6, TL-J=1/8
 
-If you add a new rule that should actually affect calculations, wire it through real game state (like the Antimatter Plant is) rather than `activeRules.has('rule_id')`, unless you're also adding the code that reads it.
+If you add a new rule that should actually affect calculations, wire it through real game state (like the Antimatter Plant is) rather than `activeRules.has('rule_id')`, unless you're also adding the code that reads it (as `'robotics'` does).
 
 ### Print Functionality
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ import { createEmptyShipDesign, createDefaultShip } from './utils/shipDefaults';
 import { sumMass, sumMassWithQuantity, sumCost, sumCostWithQuantity, sumCargoTonnage } from './utils/calculations';
 import { rescaleEnginesForTonnage, rescaleFittingsForTonnage } from './utils/tonnageRescale';
 import { cleanupVehiclesForTechLevel, cleanupBayWeaponsForTechLevel, cleanupScreensForTechLevel } from './utils/techLevelCleanup';
-import { calculatePilotCount, calculateNavigatorCount } from './utils/crewCalculations';
+import { calculatePilotCount, calculateNavigatorCount, calculateEngineerCount } from './utils/crewCalculations';
 import { generateShipPrintContent } from './utils/printContent';
 // Eagerly load only the ship selection panel (first screen)
 import SelectShipPanel from './components/SelectShipPanel';
@@ -193,14 +193,13 @@ function App() {
     const pilot = calculatePilotCount(maneuverPerformance);
     const navigator = calculateNavigatorCount(shipDesign.ship.atmosphere_support);
 
-    // Engineer count based on engine mass (megastructures are large ships)
-    const engineCount = shipDesign.engines.length;
-    let engineers = Math.max(engineCount, 1);
-    for (const engine of shipDesign.engines) {
-      if (engine.mass > 100) {
-        engineers += Math.ceil(engine.mass / 100) - 1;
-      }
-    }
+    // Engineer count based on engine mass (megastructures are large ships).
+    // Robotics (TL-F+ Rules menu toggle) reduces per-engine crew requirements.
+    const engineers = calculateEngineerCount(
+      shipDesign.engines,
+      shipDesign.ship.tech_level,
+      activeRules.has('robotics')
+    );
 
     const bayWeaponNames = BAY_WEAPON_TYPES.map(b => b.name);
     let turretsAndBarbettesGunners = 0;
@@ -244,7 +243,7 @@ function App() {
     const total = pilot + navigator + engineers + gunners + service + stewards + nurses + surgeons + techs;
 
     return { pilot, navigator, engineers, gunners, service, stewards, nurses, surgeons, techs, total };
-  }, [shipDesign]);
+  }, [shipDesign, activeRules]);
 
   const handleFilePrint = useCallback(() => {
     logger.info(`Printing megastructure "${shipDesign.ship.name}"`);

--- a/src/components/RulesMenu.test.tsx
+++ b/src/components/RulesMenu.test.tsx
@@ -55,6 +55,64 @@ describe('RulesMenu Tech Level Restrictions', () => {
       // Should not call onRuleChange for disabled rule
       expect(mockOnRuleChange).not.toHaveBeenCalled();
     });
+
+    it('should disable Robotics for TL A ship', () => {
+      const shipDesign = createMockShipDesign('A');
+      render(<RulesMenu shipDesign={shipDesign} onRuleChange={mockOnRuleChange} />);
+
+      fireEvent.click(screen.getByText('Rules'));
+
+      const roboticsItem = screen.getByText('Robotics').closest('button');
+
+      expect(roboticsItem?.classList.contains('disabled')).toBe(true);
+    });
+
+    it('should enable Robotics for TL F ship', () => {
+      const shipDesign = createMockShipDesign('F');
+      render(<RulesMenu shipDesign={shipDesign} onRuleChange={mockOnRuleChange} />);
+
+      fireEvent.click(screen.getByText('Rules'));
+
+      const roboticsItem = screen.getByText('Robotics').closest('button');
+
+      expect(roboticsItem?.classList.contains('disabled')).toBe(false);
+    });
+
+    it('should allow toggling Robotics for TL F ship', () => {
+      const shipDesign = createMockShipDesign('F');
+      render(<RulesMenu shipDesign={shipDesign} onRuleChange={mockOnRuleChange} />);
+
+      fireEvent.click(screen.getByText('Rules'));
+
+      const roboticsItem = screen.getByText('Robotics').closest('button');
+      fireEvent.click(roboticsItem!);
+
+      expect(mockOnRuleChange).toHaveBeenCalledWith('robotics', true);
+    });
+  });
+
+  describe('Robotics below TL-F', () => {
+    it('should not allow toggling Robotics for TL E ship', () => {
+      const shipDesign = createMockShipDesign('E');
+      render(<RulesMenu shipDesign={shipDesign} onRuleChange={mockOnRuleChange} />);
+
+      fireEvent.click(screen.getByText('Rules'));
+
+      const roboticsItem = screen.getByText('Robotics').closest('button');
+      fireEvent.click(roboticsItem!);
+
+      expect(mockOnRuleChange).not.toHaveBeenCalled();
+    });
+
+    it('should show tooltip for Robotics tech level restriction', () => {
+      const shipDesign = createMockShipDesign('E');
+      render(<RulesMenu shipDesign={shipDesign} onRuleChange={mockOnRuleChange} />);
+
+      fireEvent.click(screen.getByText('Rules'));
+
+      const roboticsIcon = screen.getByText('Robotics').closest('button')?.querySelector('.rule-status.disabled');
+      expect(roboticsIcon?.getAttribute('title')).toBe('Requires Tech Level F (current: E)');
+    });
   });
 
   describe('Tech Level G Ships', () => {

--- a/src/components/RulesMenu.tsx
+++ b/src/components/RulesMenu.tsx
@@ -22,7 +22,8 @@ const RulesMenu: React.FC<RulesMenuProps> = ({ shipDesign, onRuleChange }) => {
   // Calculate tech level restrictions dynamically
   const currentTechLevel = shipDesign.ship.tech_level;
   const canUseAntimatter = isTechLevelAtLeast(currentTechLevel, 'H');
-  
+  const canUseRobotics = isTechLevelAtLeast(currentTechLevel, 'F');
+
   const [enabledRuleIds, setEnabledRuleIds] = useState<Set<string>>(
     new Set(['spacecraft_design_srd'])
   );
@@ -35,6 +36,9 @@ const RulesMenu: React.FC<RulesMenuProps> = ({ shipDesign, onRuleChange }) => {
     { id: 'antimatter', name: 'Antimatter',
       enabled: enabledRuleIds.has('antimatter') && canUseAntimatter,
       disabled: !canUseAntimatter },
+    { id: 'robotics', name: 'Robotics',
+      enabled: enabledRuleIds.has('robotics') && canUseRobotics,
+      disabled: !canUseRobotics },
   ];
 
   const toggleRule = (ruleId: string) => {
@@ -62,6 +66,9 @@ const RulesMenu: React.FC<RulesMenuProps> = ({ shipDesign, onRuleChange }) => {
       // Show special indicators for tech-level restricted rules
       if (rule.id === 'antimatter' && !canUseAntimatter) {
         return <span className="rule-status disabled" title={`Requires Tech Level H (current: ${currentTechLevel})`}>—</span>;
+      }
+      if (rule.id === 'robotics' && !canUseRobotics) {
+        return <span className="rule-status disabled" title={`Requires Tech Level F (current: ${currentTechLevel})`}>—</span>;
       }
       return <span className="rule-status disabled">—</span>;
     }

--- a/src/data/constants.test.ts
+++ b/src/data/constants.test.ts
@@ -6,6 +6,7 @@ import {
   calculateEngineMassAndCost,
   getAvailableEngines,
   getMaxPowerPlantByTechLevel,
+  getRoboticsCrewDivisor,
   hasAntimatterPlant,
   calculateAntimatterAdjustedManeuverFuel,
   getWeaponMountLimit,
@@ -156,6 +157,20 @@ describe('getMaxPowerPlantByTechLevel', () => {
     expect(getMaxPowerPlantByTechLevel('G')).toBe(8);
     expect(getMaxPowerPlantByTechLevel('H')).toBe(10);
     expect(getMaxPowerPlantByTechLevel('J')).toBe(12);
+  });
+});
+
+describe('getRoboticsCrewDivisor', () => {
+  it('applies no reduction below TL-F', () => {
+    expect(getRoboticsCrewDivisor('A')).toBe(1);
+    expect(getRoboticsCrewDivisor('E')).toBe(1);
+  });
+
+  it('steps up with tech level: F=2, G=4, H=6, J=8', () => {
+    expect(getRoboticsCrewDivisor('F')).toBe(2);
+    expect(getRoboticsCrewDivisor('G')).toBe(4);
+    expect(getRoboticsCrewDivisor('H')).toBe(6);
+    expect(getRoboticsCrewDivisor('J')).toBe(8);
   });
 });
 

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -31,6 +31,18 @@ export function getMaxPowerPlantByTechLevel(techLevel: string): number {
   return 6;
 }
 
+// Robotics (TL-F+, toggled via the Rules menu): robot workers assist each
+// engineer, letting them cover more of an engine's own crew requirement as
+// tech level improves. Divisor to apply (rounded up) to each engine's crew:
+// TL-F=1/2, TL-G=1/4, TL-H=1/6, TL-J=1/8. Below TL-F, no reduction (1).
+export function getRoboticsCrewDivisor(techLevel: string): number {
+  if (isTechLevelAtLeast(techLevel, 'J')) return 8;
+  if (isTechLevelAtLeast(techLevel, 'H')) return 6;
+  if (isTechLevelAtLeast(techLevel, 'G')) return 4;
+  if (isTechLevelAtLeast(techLevel, 'F')) return 2;
+  return 1;
+}
+
 // Engine performance percentages as a function of ship displacement.
 // Levels 1-6 are from the Traveller SRD. Megastructures have no jump drive,
 // so power plant levels 7-12 extend the same +1.0%/step progression from

--- a/src/utils/crewCalculations.test.ts
+++ b/src/utils/crewCalculations.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from '@jest/globals';
-import { calculatePilotCount, calculateNavigatorCount } from './crewCalculations';
+import { calculatePilotCount, calculateNavigatorCount, calculateEngineerCount } from './crewCalculations';
 
 describe('calculatePilotCount', () => {
   it('requires 8 pilots (24x7 coverage with spares) at M-1 or better', () => {
@@ -20,5 +20,55 @@ describe('calculateNavigatorCount', () => {
 
   it('requires 4 navigators when atmosphere support is enabled', () => {
     expect(calculateNavigatorCount(true)).toBe(4);
+  });
+});
+
+describe('calculateEngineerCount', () => {
+  it('requires a minimum of 1 engineer even with no engines configured', () => {
+    expect(calculateEngineerCount([], 'A', false)).toBe(1);
+  });
+
+  it('requires 1 engineer per engine when none exceed 100 tons', () => {
+    const engines = [{ mass: 50 }, { mass: 80 }, { mass: 99 }];
+    expect(calculateEngineerCount(engines, 'A', false)).toBe(3);
+  });
+
+  it('adds extra engineers for engines over 100 tons', () => {
+    // 250t: 1 + ceil(250/100) - 1 = 3
+    expect(calculateEngineerCount([{ mass: 250 }], 'A', false)).toBe(3);
+  });
+
+  it('ignores robotics when disabled, regardless of tech level', () => {
+    expect(calculateEngineerCount([{ mass: 1300 }], 'J', false)).toBe(13);
+  });
+
+  it('applies the TL-F robotics divisor (1/2, rounded up) per engine', () => {
+    // baseCrew 13 -> ceil(13/2) = 7
+    expect(calculateEngineerCount([{ mass: 1300 }], 'F', true)).toBe(7);
+  });
+
+  it('applies the TL-G robotics divisor (1/4, rounded up) per engine', () => {
+    // baseCrew 13 -> ceil(13/4) = 4
+    expect(calculateEngineerCount([{ mass: 1300 }], 'G', true)).toBe(4);
+  });
+
+  it('applies the TL-H robotics divisor (1/6, rounded up) per engine', () => {
+    // baseCrew 13 -> ceil(13/6) = 3
+    expect(calculateEngineerCount([{ mass: 1300 }], 'H', true)).toBe(3);
+  });
+
+  it('applies the TL-J robotics divisor (1/8, rounded up) per engine', () => {
+    // baseCrew 13 -> ceil(13/8) = 2
+    expect(calculateEngineerCount([{ mass: 1300 }], 'J', true)).toBe(2);
+  });
+
+  it('reduces below TL-F to no effect (divisor 1) even if somehow enabled', () => {
+    expect(calculateEngineerCount([{ mass: 1300 }], 'E', true)).toBe(13);
+  });
+
+  it('applies the per-engine reduction independently before summing', () => {
+    // Two 150t engines: baseCrew 2 each -> ceil(2/2) = 1 each -> total 2
+    const engines = [{ mass: 150 }, { mass: 150 }];
+    expect(calculateEngineerCount(engines, 'F', true)).toBe(2);
   });
 });

--- a/src/utils/crewCalculations.ts
+++ b/src/utils/crewCalculations.ts
@@ -1,3 +1,5 @@
+import { getRoboticsCrewDivisor } from '../data/constants';
+
 // A megastructure under way (M-1+) needs round-the-clock piloting: 24x7
 // coverage plus spares works out to 8 pilots. A stationary structure (M-0,
 // no maneuver drive) just needs a skeleton crew for station-keeping/docking.
@@ -10,4 +12,25 @@ export function calculatePilotCount(maneuverPerformance: number): number {
 // structure, which needs active navigation and carries 4 navigators.
 export function calculateNavigatorCount(atmosphereSupport: boolean | undefined): number {
   return atmosphereSupport ? 4 : 0;
+}
+
+// Engineer count: 1 per engine (minimum 1 total, even with none configured),
+// plus extra engineers for any engine over 100 tons. Robotics (TL-F+,
+// toggled via the Rules menu) divides each engine's own crew requirement
+// down, rounded up, by a tech-level-scaled factor — see
+// getRoboticsCrewDivisor. Applied per engine (not to the summed total) so
+// each engine's robot-assisted reduction rounds up independently.
+export function calculateEngineerCount(
+  engines: { mass: number }[],
+  techLevel: string,
+  roboticsEnabled: boolean
+): number {
+  if (engines.length === 0) return 1;
+
+  const divisor = roboticsEnabled ? getRoboticsCrewDivisor(techLevel) : 1;
+
+  return engines.reduce((sum, engine) => {
+    const baseCrew = 1 + (engine.mass > 100 ? Math.ceil(engine.mass / 100) - 1 : 0);
+    return sum + Math.ceil(baseCrew / divisor);
+  }, 0);
 }


### PR DESCRIPTION
## Summary
- Adds "Robotics" to the Rules menu, gated to TL-F+ (same pattern as Antimatter's TL-H+ gate).
- When enabled, each engine's own crew requirement is divided (rounded up, per engine) by a tech-level-scaled factor:

| Tech Level | Crew divisor |
|---|---|
| TL-F | 1/2 |
| TL-G | 1/4 |
| TL-H | 1/6 |
| TL-J | 1/8 |

- This is one of the few `activeRules` toggles that actually affects a calculation (see CLAUDE.md's Rules System section) — `calculateStaffRequirements()` reads `activeRules.has('robotics')` directly, since Robotics doesn't correspond to an installed component the way the Antimatter Plant does.
- Extracted the engineer-count formula out of `App.tsx` into `calculateEngineerCount()` in `src/utils/crewCalculations.ts` (alongside the existing pilot/navigator formulas) so it's directly unit-testable, and added `getRoboticsCrewDivisor()` to `constants.ts` next to `getMaxPowerPlantByTechLevel()`.
- Reduction is applied per-engine before summing (not to the summed total), so each engine's rounding-up happens independently.

## Test plan
- [x] `pnpm lint` — 0 errors/warnings
- [x] `pnpm test:run` — 207/207 passing (17 new tests: divisor table, engineer-count formula at each TL, RulesMenu gating/tooltip/toggle behavior for Robotics)
- [x] `pnpm build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXHBvdJ5mLZTWFRChrvkoU