### PR TITLE
Add custom crew tracking to the Custom panel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ aid/
 │   │   ├── CargoPanel.tsx      # Cargo bays (panel 6)
 │   │   ├── VehiclesPanel.tsx   # Vehicles (panel 7)
 │   │   ├── DronesPanel.tsx     # Drones (panel 8)
-│   │   ├── CustomPanel.tsx     # Custom items (panel 9)
+│   │   ├── CustomPanel.tsx     # Custom items + custom crew (panel 9)
 │   │   ├── FuelPanel.tsx       # Fuel scoops, processors, tanks, antimatter plant (panel 10)
 │   │   ├── SectionsPanel.tsx   # Zone sections — residential/industrial/farm/etc. (panel 11)
 │   │   ├── BerthsPanel.tsx     # Berths (panel 12)
@@ -169,8 +169,9 @@ Test files are co-located with source files using .test.ts/.test.tsx extension
 **`src/types/ship.ts`**: TypeScript interfaces for all ship components
 - `ShipDesign`: Root interface containing all component arrays
 - `Ship`: includes `atmosphere_support?: boolean` — a floating-city-style structure that needs active navigation (see Staff Requirements Logic)
-- Component interfaces: `Engine` (`engine_type: 'power_plant' | 'maneuver_drive'`, no jump drive), `Fitting` (`fitting_type: 'control_center' | 'launch_tube' | 'comms_sensors' | 'computer'`, no bridge), `Weapon`, `Defense`, `Berth`, `Facility`, `Cargo`, `Vehicle`, `Drone`, `CustomItem`, `FuelSystem`, `ZoneSection`
+- Component interfaces: `Engine` (`engine_type: 'power_plant' | 'maneuver_drive'`, no jump drive), `Fitting` (`fitting_type: 'control_center' | 'launch_tube' | 'comms_sensors' | 'computer'`, no bridge), `Weapon`, `Defense`, `Berth`, `Facility`, `Cargo`, `Vehicle`, `Drone`, `CustomItem`, `CustomCrew`, `FuelSystem`, `ZoneSection`
 - `CustomItem`: User-defined items with name, mass, and cost (no predefined types)
+- `CustomCrew`: a single object (not an array) on `ShipDesign`, holding a count per crew category to operate/service/repair/serve custom items — the same 9 positions shown on the Staff panel (pilot/navigator/engineers/gunners/service/stewards/nurses/surgeons/techs), plus 4 that exist only as custom-crew entries (infantry/armor/mp/security, no baseline formula elsewhere). Every count adds directly onto the corresponding `StaffRequirements` field in `calculateStaffRequirements()` (see Staff Requirements Logic)
 - `StaffRequirements`: Crew calculation results
 
 ### Component Architecture
@@ -318,6 +319,7 @@ Crew calculation in `calculateStaffRequirements()` (hoisted before JSX return in
 - **Stewards**: 1 per 8 staterooms (rounded up)
 - **Medical**: Calculated by `calculateMedicalStaff()` based on medical facilities
 - **Service**: Vehicle service (`calculateVehicleServiceStaff`) + drone service (`calculateDroneServiceStaff`) from `constants.ts`
+- **Custom Crew** (`shipDesign.custom_crew`, entered on the Custom panel — see Common Modifications): added directly onto the corresponding field above for the 9 shared positions (pilot/navigator/engineers/gunners/service/stewards/nurses/surgeons/techs). **Infantry/Armor/MP/Security** have no baseline formula anywhere else in the app, so their `StaffRequirements` values are exactly whatever's entered as custom crew
 
 There is no small-ship pilot/navigator-combining or no-stewards toggle on this branch (that convention only applied to exactly-100/200-ton starships on the `main` branch; megastructures start at 1,000,000 tons, so it never applied here and was removed as dead code).
 
@@ -417,6 +419,7 @@ The Custom panel (`src/components/CustomPanel.tsx`, panel index 9) demonstrates 
 - **UI Pattern**: Form with text/number inputs + table with remove buttons
 - **Different from other panels**: No predefined types or constants - fully user-defined
 - **Integration**: Same as other panels - appears in mass/cost calculations, CSV export, summary, print
+- **Custom Crew**: a second section on the same panel, gated on `custom_items.length > 0` (hidden entirely until at least one custom item exists, rather than shown-but-disabled). Iterates `CUSTOM_CREW_CATEGORIES` (`src/data/constants.ts`) to render one number input per crew position; unlike `CustomItem`, this list of categories **is** predefined (it mirrors the Staff panel's positions plus infantry/armor/mp/security) since the whole point is tracking crew against known position types, not arbitrary user-named ones
 
 **Modifying validation**:
 - Panel-specific validation in `isCurrentPanelValid()` switch statement

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -238,11 +238,30 @@ function App() {
     const stewards = Math.ceil(totalStaterooms / 8);
 
     const medicalStaff = calculateMedicalStaff(shipDesign.facilities);
-    const { nurses, surgeons, techs } = medicalStaff;
+    const { nurses: baseNurses, surgeons: baseSurgeons, techs: baseTechs } = medicalStaff;
 
-    const total = pilot + navigator + engineers + gunners + service + stewards + nurses + surgeons + techs;
+    // Crew assigned to operate/service/repair/serve custom items adds onto
+    // the corresponding position; infantry/armor/mp/security have no
+    // baseline formula elsewhere, so they're purely custom-crew-driven.
+    const customCrew = shipDesign.custom_crew;
+    const pilotTotal = pilot + customCrew.pilot;
+    const navigatorTotal = navigator + customCrew.navigator;
+    const engineersTotal = engineers + customCrew.engineers;
+    const gunnersTotal = gunners + customCrew.gunners;
+    const serviceTotal = service + customCrew.service;
+    const stewardsTotal = stewards + customCrew.stewards;
+    const nurses = baseNurses + customCrew.nurses;
+    const surgeons = baseSurgeons + customCrew.surgeons;
+    const techs = baseTechs + customCrew.techs;
+    const { infantry, armor, mp, security } = customCrew;
 
-    return { pilot, navigator, engineers, gunners, service, stewards, nurses, surgeons, techs, total };
+    const total = pilotTotal + navigatorTotal + engineersTotal + gunnersTotal + serviceTotal + stewardsTotal
+      + nurses + surgeons + techs + infantry + armor + mp + security;
+
+    return {
+      pilot: pilotTotal, navigator: navigatorTotal, engineers: engineersTotal, gunners: gunnersTotal,
+      service: serviceTotal, stewards: stewardsTotal, nurses, surgeons, techs, infantry, armor, mp, security, total
+    };
   }, [shipDesign, activeRules]);
 
   const handleFilePrint = useCallback(() => {
@@ -505,7 +524,12 @@ function App() {
       case 8:
         return <DronesPanel drones={shipDesign.drones} onUpdate={(drones) => updateShipDesign({ drones })} />;
       case 9:
-        return <CustomPanel custom_items={shipDesign.custom_items} onUpdate={(custom_items) => updateShipDesign({ custom_items })} />;
+        return <CustomPanel
+          custom_items={shipDesign.custom_items}
+          custom_crew={shipDesign.custom_crew}
+          onUpdate={(custom_items) => updateShipDesign({ custom_items })}
+          onCrewUpdate={(custom_crew) => updateShipDesign({ custom_crew })}
+        />;
       case 10:
         return <FuelPanel
           fuelSystems={shipDesign.fuel_systems || []}

--- a/src/components/CustomPanel.test.tsx
+++ b/src/components/CustomPanel.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import '@testing-library/jest-dom';
+import CustomPanel from './CustomPanel';
+import type { CustomItem, CustomCrew } from '../types/ship';
+
+const emptyCrew: CustomCrew = {
+  pilot: 0, navigator: 0, engineers: 0, gunners: 0, service: 0, stewards: 0,
+  nurses: 0, surgeons: 0, techs: 0, infantry: 0, armor: 0, mp: 0, security: 0,
+};
+
+describe('CustomPanel custom crew section', () => {
+  const mockOnUpdate = jest.fn();
+  const mockOnCrewUpdate = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('hides the custom crew section when there are no custom items', () => {
+    render(<CustomPanel custom_items={[]} custom_crew={emptyCrew} onUpdate={mockOnUpdate} onCrewUpdate={mockOnCrewUpdate} />);
+    expect(screen.queryByText('Custom Crew')).not.toBeInTheDocument();
+  });
+
+  it('shows the custom crew section once a custom item has been added', () => {
+    const items: CustomItem[] = [{ name: 'Sensor Pod', mass: 5, cost: 2 }];
+    render(<CustomPanel custom_items={items} custom_crew={emptyCrew} onUpdate={mockOnUpdate} onCrewUpdate={mockOnCrewUpdate} />);
+    expect(screen.getByText('Custom Crew')).toBeInTheDocument();
+  });
+
+  it('shows a number entry for every crew category', () => {
+    const items: CustomItem[] = [{ name: 'Sensor Pod', mass: 5, cost: 2 }];
+    render(<CustomPanel custom_items={items} custom_crew={emptyCrew} onUpdate={mockOnUpdate} onCrewUpdate={mockOnCrewUpdate} />);
+    ['Pilot', 'Navigator', 'Engineers', 'Gunners', 'Service', 'Stewards', 'Nurses', 'Surgeons', 'Techs',
+      'Infantry', 'Armor', 'MP', 'Security'].forEach(label => {
+      expect(screen.getByLabelText(label)).toBeInTheDocument();
+    });
+  });
+
+  it('calls onCrewUpdate with the changed category when a crew count is edited', () => {
+    const items: CustomItem[] = [{ name: 'Sensor Pod', mass: 5, cost: 2 }];
+    render(<CustomPanel custom_items={items} custom_crew={emptyCrew} onUpdate={mockOnUpdate} onCrewUpdate={mockOnCrewUpdate} />);
+
+    fireEvent.change(screen.getByLabelText('Infantry'), { target: { value: '4' } });
+
+    expect(mockOnCrewUpdate).toHaveBeenCalledWith({ ...emptyCrew, infantry: 4 });
+  });
+
+  it('preserves other category counts when one is changed', () => {
+    const items: CustomItem[] = [{ name: 'Sensor Pod', mass: 5, cost: 2 }];
+    const crew: CustomCrew = { ...emptyCrew, security: 2 };
+    render(<CustomPanel custom_items={items} custom_crew={crew} onUpdate={mockOnUpdate} onCrewUpdate={mockOnCrewUpdate} />);
+
+    fireEvent.change(screen.getByLabelText('MP'), { target: { value: '3' } });
+
+    expect(mockOnCrewUpdate).toHaveBeenCalledWith({ ...crew, mp: 3 });
+  });
+
+  it('treats a negative or invalid entry as zero', () => {
+    const items: CustomItem[] = [{ name: 'Sensor Pod', mass: 5, cost: 2 }];
+    render(<CustomPanel custom_items={items} custom_crew={emptyCrew} onUpdate={mockOnUpdate} onCrewUpdate={mockOnCrewUpdate} />);
+
+    fireEvent.change(screen.getByLabelText('Armor'), { target: { value: '-5' } });
+
+    expect(mockOnCrewUpdate).toHaveBeenCalledWith({ ...emptyCrew, armor: 0 });
+  });
+});

--- a/src/components/CustomPanel.tsx
+++ b/src/components/CustomPanel.tsx
@@ -1,12 +1,15 @@
 import React, { useState } from 'react';
-import type { CustomItem } from '../types/ship';
+import type { CustomItem, CustomCrew } from '../types/ship';
+import { CUSTOM_CREW_CATEGORIES } from '../data/constants';
 
 interface CustomPanelProps {
   custom_items: CustomItem[];
+  custom_crew: CustomCrew;
   onUpdate: (custom_items: CustomItem[]) => void;
+  onCrewUpdate: (custom_crew: CustomCrew) => void;
 }
 
-const CustomPanel: React.FC<CustomPanelProps> = ({ custom_items, onUpdate }) => {
+const CustomPanel: React.FC<CustomPanelProps> = ({ custom_items, custom_crew, onUpdate, onCrewUpdate }) => {
   const [newItemName, setNewItemName] = useState('');
   const [newItemMass, setNewItemMass] = useState('');
   const [newItemCost, setNewItemCost] = useState('');
@@ -41,6 +44,11 @@ const CustomPanel: React.FC<CustomPanelProps> = ({ custom_items, onUpdate }) => 
   const handleRemoveItem = (index: number) => {
     const newItems = custom_items.filter((_, i) => i !== index);
     onUpdate(newItems);
+  };
+
+  const handleCrewChange = (key: keyof CustomCrew, value: string) => {
+    const count = Math.max(0, parseInt(value, 10) || 0);
+    onCrewUpdate({ ...custom_crew, [key]: count });
   };
 
   const totalMass = custom_items.reduce((sum, item) => sum + item.mass, 0);
@@ -132,6 +140,28 @@ const CustomPanel: React.FC<CustomPanelProps> = ({ custom_items, onUpdate }) => 
           </>
         )}
       </div>
+
+      {custom_items.length > 0 && (
+        <div className="custom-crew">
+          <h3>Custom Crew</h3>
+          <p>Crew to operate, service, repair, and serve the custom items above. Added to the ship's total Staff Requirements.</p>
+          <div className="form-row">
+            {CUSTOM_CREW_CATEGORIES.map(({ key, label }) => (
+              <div key={key} className="form-group">
+                <label htmlFor={`custom-crew-${key}`}>{label}</label>
+                <input
+                  id={`custom-crew-${key}`}
+                  type="number"
+                  step="1"
+                  min="0"
+                  value={custom_crew[key]}
+                  onChange={(e) => handleCrewChange(key, e.target.value)}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/SelectShipPanel.tsx
+++ b/src/components/SelectShipPanel.tsx
@@ -3,6 +3,7 @@ import { databaseService, type StoredShipDesign } from '../services/database';
 import { initialDataService } from '../services/initialDataService';
 import type { ShipDesign } from '../types/ship';
 import { logger } from '../utils/logger';
+import { createEmptyCustomCrew } from '../utils/shipDefaults';
 
 interface SelectShipPanelProps {
   onNewShip: () => void;
@@ -50,6 +51,7 @@ function createDefaultShips() {
       vehicles: [],
       drones: [],
       custom_items: [],
+      custom_crew: createEmptyCustomCrew(),
       fuel_systems: [
         { system_type: 'fuel_scoop' as const, quantity: 1000, mass: 0, cost: 1000 },
         { system_type: 'fuel_processor' as const, quantity: 10, mass: 10000, cost: 500 },

--- a/src/components/ShipPanel.tsx
+++ b/src/components/ShipPanel.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import type { Ship, ShipDesign } from '../types/ship';
 import { TECH_LEVELS, MEGASTRUCTURE_HULL_SIZES, getMegastructureSections } from '../data/constants';
 import { databaseService } from '../services/database';
+import { createEmptyCustomCrew } from '../utils/shipDefaults';
 
 interface ShipPanelProps {
   ship: Ship;
@@ -50,6 +51,7 @@ const ShipPanel: React.FC<ShipPanelProps> = ({ ship, onUpdate, onLoadExistingShi
             vehicles: existingShip.vehicles,
             drones: existingShip.drones,
             custom_items: existingShip.custom_items || [],
+            custom_crew: existingShip.custom_crew || createEmptyCustomCrew(),
             fuel_systems: existingShip.fuel_systems || [],
             zone_sections: existingShip.zone_sections || []
           }

--- a/src/components/StaffPanel.tsx
+++ b/src/components/StaffPanel.tsx
@@ -21,6 +21,10 @@ const StaffPanel: React.FC<StaffPanelProps> = ({ staffRequirements, berths }) =>
         <p>Nurses: {staffRequirements.nurses}</p>
         <p>Surgeons: {staffRequirements.surgeons}</p>
         <p>Techs: {staffRequirements.techs}</p>
+        {staffRequirements.infantry > 0 && <p>Infantry: {staffRequirements.infantry}</p>}
+        {staffRequirements.armor > 0 && <p>Armor: {staffRequirements.armor}</p>}
+        {staffRequirements.mp > 0 && <p>MP: {staffRequirements.mp}</p>}
+        {staffRequirements.security > 0 && <p>Security: {staffRequirements.security}</p>}
         <p><strong>Total Staff: {staffRequirements.total}</strong></p>
       </div>
 

--- a/src/components/SummaryPanel.tsx
+++ b/src/components/SummaryPanel.tsx
@@ -461,6 +461,10 @@ const SummaryPanel: React.FC<SummaryPanelProps> = ({ shipDesign, mass, cost, sta
         {staff.nurses > 0 && <p><strong>Nurses:</strong> {staff.nurses}</p>}
         {staff.surgeons > 0 && <p><strong>Surgeons:</strong> {staff.surgeons}</p>}
         {staff.techs > 0 && <p><strong>Medical Techs:</strong> {staff.techs}</p>}
+        {staff.infantry > 0 && <p><strong>Infantry:</strong> {staff.infantry}</p>}
+        {staff.armor > 0 && <p><strong>Armor:</strong> {staff.armor}</p>}
+        {staff.mp > 0 && <p><strong>MP:</strong> {staff.mp}</p>}
+        {staff.security > 0 && <p><strong>Security:</strong> {staff.security}</p>}
         <p><strong>Total:</strong> {staff.total}</p>
       </div>
 

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -1,4 +1,23 @@
-import type { Cargo } from '../types/ship';
+import type { Cargo, CustomCrew } from '../types/ship';
+
+// Crew categories shown on the Custom panel's crew-tracking section, in
+// display order - the same positions shown on the Staff panel, plus four
+// (infantry/armor/mp/security) that only exist as custom-crew entries.
+export const CUSTOM_CREW_CATEGORIES: { key: keyof CustomCrew; label: string }[] = [
+  { key: 'pilot', label: 'Pilot' },
+  { key: 'navigator', label: 'Navigator' },
+  { key: 'engineers', label: 'Engineers' },
+  { key: 'gunners', label: 'Gunners' },
+  { key: 'service', label: 'Service' },
+  { key: 'stewards', label: 'Stewards' },
+  { key: 'nurses', label: 'Nurses' },
+  { key: 'surgeons', label: 'Surgeons' },
+  { key: 'techs', label: 'Techs' },
+  { key: 'infantry', label: 'Infantry' },
+  { key: 'armor', label: 'Armor' },
+  { key: 'mp', label: 'MP' },
+  { key: 'security', label: 'Security' },
+];
 
 // TL letters skip 'I' (visual confusion with the digit 1), matching the
 // Traveller convention: ...H=17, I skipped, J=18, K=19...

--- a/src/types/ship.ts
+++ b/src/types/ship.ts
@@ -94,6 +94,26 @@ export interface CustomItem {
   cost: number;
 }
 
+// Crew assigned specifically to operate/service/repair/serve custom items.
+// Uses the same position categories as StaffRequirements, plus four that
+// have no other source in this app (infantry/armor/mp/security have no
+// baseline formula elsewhere - they're purely custom-crew-driven).
+export interface CustomCrew {
+  pilot: number;
+  navigator: number;
+  engineers: number;
+  gunners: number;
+  service: number;
+  stewards: number;
+  nurses: number;
+  surgeons: number;
+  techs: number;
+  infantry: number;
+  armor: number;
+  mp: number;
+  security: number;
+}
+
 export interface FuelSystem {
   id?: number;
   system_type: 'fuel_scoop' | 'fuel_processor' | 'fuel_tank' | 'antimatter_plant';
@@ -120,6 +140,10 @@ export interface StaffRequirements {
   nurses: number;
   surgeons: number;
   techs: number;
+  infantry: number;
+  armor: number;
+  mp: number;
+  security: number;
   total: number;
 }
 
@@ -135,6 +159,7 @@ export interface ShipDesign {
   vehicles: Vehicle[];
   drones: Drone[];
   custom_items: CustomItem[];
+  custom_crew: CustomCrew;
   fuel_systems: FuelSystem[];
   zone_sections: ZoneSection[];
 }

--- a/src/utils/printContent.test.ts
+++ b/src/utils/printContent.test.ts
@@ -6,7 +6,8 @@ const baseMass: MassCalculation = { total: 1_000_000, used: 120_000, remaining: 
 const baseCost: CostCalculation = { total: 45.5 };
 const baseStaff: StaffRequirements = {
   pilot: 8, navigator: 0, engineers: 2, gunners: 0,
-  service: 0, stewards: 0, nurses: 0, surgeons: 0, techs: 0, total: 10,
+  service: 0, stewards: 0, nurses: 0, surgeons: 0, techs: 0,
+  infantry: 0, armor: 0, mp: 0, security: 0, total: 10,
 };
 const baseRules = new Set(['spacecraft_design_srd']);
 
@@ -38,6 +39,10 @@ const baseShip: ShipDesign = {
   vehicles: [],
   drones: [],
   custom_items: [],
+  custom_crew: {
+    pilot: 0, navigator: 0, engineers: 0, gunners: 0, service: 0, stewards: 0,
+    nurses: 0, surgeons: 0, techs: 0, infantry: 0, armor: 0, mp: 0, security: 0,
+  },
   fuel_systems: [],
   zone_sections: [],
 };
@@ -280,5 +285,22 @@ describe('generateShipPrintContent', () => {
     expect(html).toContain('Nurses');
     expect(html).toContain('Surgeons');
     expect(html).toContain('Medical Techs');
+  });
+
+  it('should hide custom crew rows (infantry/armor/mp/security) when zero', () => {
+    const html = generateShipPrintContent(baseShip, baseMass, baseCost, baseStaff, baseRules);
+    expect(html).not.toContain('Infantry');
+    expect(html).not.toContain('Armor');
+    expect(html).not.toContain('>MP:<');
+    expect(html).not.toContain('Security');
+  });
+
+  it('should show custom crew rows (infantry/armor/mp/security) only when present', () => {
+    const staffWithCustomCrew = { ...baseStaff, infantry: 4, armor: 2, mp: 1, security: 3, total: 20 };
+    const html = generateShipPrintContent(baseShip, baseMass, baseCost, staffWithCustomCrew, baseRules);
+    expect(html).toContain('Infantry');
+    expect(html).toContain('Armor');
+    expect(html).toContain('>MP:<');
+    expect(html).toContain('Security');
   });
 });

--- a/src/utils/printContent.ts
+++ b/src/utils/printContent.ts
@@ -195,6 +195,10 @@ export function generateShipPrintContent(
   if (staff.nurses > 0) crewLines.push(`<p><strong>Nurses:</strong> ${staff.nurses}</p>`);
   if (staff.surgeons > 0) crewLines.push(`<p><strong>Surgeons:</strong> ${staff.surgeons}</p>`);
   if (staff.techs > 0) crewLines.push(`<p><strong>Medical Techs:</strong> ${staff.techs}</p>`);
+  if (staff.infantry > 0) crewLines.push(`<p><strong>Infantry:</strong> ${staff.infantry}</p>`);
+  if (staff.armor > 0) crewLines.push(`<p><strong>Armor:</strong> ${staff.armor}</p>`);
+  if (staff.mp > 0) crewLines.push(`<p><strong>MP:</strong> ${staff.mp}</p>`);
+  if (staff.security > 0) crewLines.push(`<p><strong>Security:</strong> ${staff.security}</p>`);
   crewLines.push(`<p><strong>Total Crew:</strong> ${staff.total}</p>`);
 
   return `<!DOCTYPE html>

--- a/src/utils/shipDefaults.ts
+++ b/src/utils/shipDefaults.ts
@@ -1,5 +1,21 @@
-import type { ShipDesign, Ship } from '../types/ship';
+import type { ShipDesign, Ship, CustomCrew } from '../types/ship';
 import { getMegastructureSections } from '../data/constants';
+
+export const createEmptyCustomCrew = (): CustomCrew => ({
+  pilot: 0,
+  navigator: 0,
+  engineers: 0,
+  gunners: 0,
+  service: 0,
+  stewards: 0,
+  nurses: 0,
+  surgeons: 0,
+  techs: 0,
+  infantry: 0,
+  armor: 0,
+  mp: 0,
+  security: 0
+});
 
 export const createEmptyShipDesign = (shipInfo: Ship): ShipDesign => {
   return {
@@ -21,6 +37,7 @@ export const createEmptyShipDesign = (shipInfo: Ship): ShipDesign => {
     vehicles: [],
     drones: [],
     custom_items: [],
+    custom_crew: createEmptyCustomCrew(),
     fuel_systems: [],
     zone_sections: []
   };


### PR DESCRIPTION
## Summary
- Adds a "Custom Crew" section to the Custom items panel (`src/components/CustomPanel.tsx`), **hidden until at least one custom item exists**.
- Shows one number entry per crew position: the 9 already on the Staff panel (Pilot, Navigator, Engineers, Gunners, Service, Stewards, Nurses, Surgeons, Techs) plus 4 new ones you specified — Infantry, Armor, MP, Security.
- Every count adds directly into the ship's total Staff Requirements (`calculateStaffRequirements()` in `App.tsx`):
  - The 9 shared positions add onto whatever's already auto-calculated there (e.g. custom Engineers stacks with the engine-based engineer count).
  - Infantry/Armor/MP/Security have no other formula anywhere in the app, so their totals are exactly whatever's entered as custom crew.
- New `CustomCrew` type on `ShipDesign`, defaulted to all-zero via `createEmptyCustomCrew()` everywhere a `ShipDesign` is constructed (empty design, DB name-conflict reconstruction in `ShipPanel.tsx`, and the hardcoded fallback ship in `SelectShipPanel.tsx`).
- Staff panel, Summary panel, and print output all show the 4 new categories, using the same "only show when >0" convention already used for Gunners/Nurses/Surgeons/Techs.

I double-checked the existing Staff panel category list against your description (Pilot, Navigator, Engineers, Gunners, Service, Stewards, Nurses, Surgeons, Techs) and it matches exactly — no other categories currently exist anywhere else in the app that needed folding in.

## Test plan
- [x] `pnpm lint` — 0 errors/warnings
- [x] `pnpm test:run` — 215/215 passing (8 new tests: CustomPanel show/hide + input wiring, printContent rendering of the 4 new categories)
- [x] `pnpm build` — succeeds (`tsc -b` confirms every non-test `ShipDesign`/`StaffRequirements` construction site in the app was updated for the new fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXHBvdJ5mLZTWFRChrvkoU