### PR TITLE
Switch Rec/Health quantity inputs to the Weapons panel's numeric input

### DIFF
--- a/src/components/FacilitiesPanel.tsx
+++ b/src/components/FacilitiesPanel.tsx
@@ -24,32 +24,24 @@ const FacilitiesPanel: React.FC<FacilitiesPanelProps> = ({ facilities, onUpdate 
     }
   }, [hasCommissary, facilities, onUpdate]);
 
-  const addFacility = (facilityType: typeof FACILITY_TYPES[0]) => {
+  const updateFacilityQuantity = (facilityType: typeof FACILITY_TYPES[0], requestedQuantity: number) => {
+    const validQuantity = Math.max(0, Math.floor(requestedQuantity));
     const existingFacility = facilities.find(f => f.facility_type === facilityType.type);
-    if (existingFacility) {
-      const newFacilities = facilities.map(f =>
-        f.facility_type === facilityType.type
-          ? { ...f, quantity: f.quantity + 1 }
-          : f
-      );
-      onUpdate(newFacilities);
+
+    if (validQuantity === 0) {
+      onUpdate(facilities.filter(f => f.facility_type !== facilityType.type));
+    } else if (existingFacility) {
+      onUpdate(facilities.map(f =>
+        f.facility_type === facilityType.type ? { ...f, quantity: validQuantity } : f
+      ));
     } else {
       onUpdate([...facilities, {
         facility_type: facilityType.type as Facility['facility_type'],
-        quantity: 1,
+        quantity: validQuantity,
         mass: facilityType.mass,
         cost: facilityType.cost
       }]);
     }
-  };
-
-  const removeFacility = (facilityType: string) => {
-    const newFacilities = facilities.map(f =>
-      f.facility_type === facilityType
-        ? { ...f, quantity: Math.max(0, f.quantity - 1) }
-        : f
-    ).filter(f => f.quantity > 0);
-    onUpdate(newFacilities);
   };
 
   return (
@@ -70,18 +62,16 @@ const FacilitiesPanel: React.FC<FacilitiesPanelProps> = ({ facilities, onUpdate 
                   <h4>{facilityType.name}, {facilityType.mass} tons, {facilityType.cost} MCr</h4>
                 </div>
                 <div className="quantity-control">
-                  <button 
-                    onClick={() => removeFacility(facilityType.type)}
-                    disabled={quantity === 0}
-                  >
-                    -
-                  </button>
-                  <span>{quantity}</span>
-                  <button 
-                    onClick={() => addFacility(facilityType)}
-                  >
-                    +
-                  </button>
+                  <label>
+                    Quantity:
+                    <input
+                      type="number"
+                      min="0"
+                      value={quantity}
+                      onChange={(e) => updateFacilityQuantity(facilityType, parseInt(e.target.value) || 0)}
+                      style={{ width: '60px', marginLeft: '0.5rem' }}
+                    />
+                  </label>
                 </div>
               </div>
             );
@@ -100,18 +90,16 @@ const FacilitiesPanel: React.FC<FacilitiesPanelProps> = ({ facilities, onUpdate 
                   <h4>{facilityType.name}, {facilityType.mass} tons, {facilityType.cost} MCr</h4>
                 </div>
                 <div className="quantity-control">
-                  <button 
-                    onClick={() => removeFacility(facilityType.type)}
-                    disabled={quantity === 0}
-                  >
-                    -
-                  </button>
-                  <span>{quantity}</span>
-                  <button 
-                    onClick={() => addFacility(facilityType)}
-                  >
-                    +
-                  </button>
+                  <label>
+                    Quantity:
+                    <input
+                      type="number"
+                      min="0"
+                      value={quantity}
+                      onChange={(e) => updateFacilityQuantity(facilityType, parseInt(e.target.value) || 0)}
+                      style={{ width: '60px', marginLeft: '0.5rem' }}
+                    />
+                  </label>
                 </div>
               </div>
             );
@@ -130,18 +118,16 @@ const FacilitiesPanel: React.FC<FacilitiesPanelProps> = ({ facilities, onUpdate 
                   <h4>{facilityType.name}, {facilityType.mass} tons, {facilityType.cost} MCr</h4>
                 </div>
                 <div className="quantity-control">
-                  <button 
-                    onClick={() => removeFacility(facilityType.type)}
-                    disabled={quantity === 0}
-                  >
-                    -
-                  </button>
-                  <span>{quantity}</span>
-                  <button 
-                    onClick={() => addFacility(facilityType)}
-                  >
-                    +
-                  </button>
+                  <label>
+                    Quantity:
+                    <input
+                      type="number"
+                      min="0"
+                      value={quantity}
+                      onChange={(e) => updateFacilityQuantity(facilityType, parseInt(e.target.value) || 0)}
+                      style={{ width: '60px', marginLeft: '0.5rem' }}
+                    />
+                  </label>
                 </div>
               </div>
             );
@@ -160,18 +146,16 @@ const FacilitiesPanel: React.FC<FacilitiesPanelProps> = ({ facilities, onUpdate 
                   <h4>{facilityType.name}, {facilityType.mass} tons, {facilityType.cost} MCr</h4>
                 </div>
                 <div className="quantity-control">
-                  <button 
-                    onClick={() => removeFacility(facilityType.type)}
-                    disabled={quantity === 0}
-                  >
-                    -
-                  </button>
-                  <span>{quantity}</span>
-                  <button 
-                    onClick={() => addFacility(facilityType)}
-                  >
-                    +
-                  </button>
+                  <label>
+                    Quantity:
+                    <input
+                      type="number"
+                      min="0"
+                      value={quantity}
+                      onChange={(e) => updateFacilityQuantity(facilityType, parseInt(e.target.value) || 0)}
+                      style={{ width: '60px', marginLeft: '0.5rem' }}
+                    />
+                  </label>
                 </div>
               </div>
             );


### PR DESCRIPTION
## Summary
- Rec/Health (`FacilitiesPanel.tsx`) used one-click `-`/`+` buttons for facility quantity — one click per unit, no direct entry. For megastructure-scale facility counts (hundreds of staterooms' worth of commissaries, gyms, etc.) this was extremely tedious.
- Switched to the same `<input type="number">` pattern already used throughout `WeaponsPanel.tsx`: native spinner arrows (press-and-hold rapid-increments) plus direct typed entry.
- Replaced the delta-based `addFacility`/`removeFacility` (+1/-1 per click) with an absolute-value `updateFacilityQuantity()`, matching the shape of `WeaponsPanel`'s `updateWeaponQuantity()` — the native number input reports the target value directly, not a step.
- No behavior change to the "Commissary is required" auto-add logic — reducing Commissary to 0 still triggers the existing effect to re-add it at quantity 1, same as before.

## Test plan
- [x] `pnpm lint` — 0 errors/warnings
- [x] `pnpm test:run` — 207/207 passing (no dedicated FacilitiesPanel test file existed before or after; this branch has no direct component tests, consistent with existing project convention)
- [x] `pnpm build` — succeeds
- [ ] Could not get a live browser screenshot in this environment (Chrome extension wasn't connected) — the change is a byte-for-byte copy of `WeaponsPanel`'s already-working input markup, so please give it a quick manual check in the Rec/Health panel before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXHBvdJ5mLZTWFRChrvkoU