### PR TITLE
Switch Rec/Health quantity inputs to a numeric input with direct entry

### DIFF
--- a/src/components/FacilitiesPanel.test.tsx
+++ b/src/components/FacilitiesPanel.test.tsx
@@ -30,54 +30,67 @@ describe('FacilitiesPanel', () => {
     expect(onUpdate).not.toHaveBeenCalled();
   });
 
-  it('+ button adds a new facility', () => {
+  it('typing a quantity adds a new facility', () => {
     const onUpdate = jest.fn();
     const facilities: Facility[] = [{ facility_type: 'commissary', quantity: 1, mass: 2, cost: 0.2 }];
     render(<FacilitiesPanel facilities={facilities} onUpdate={onUpdate} />);
-    // Click + for Gym (first non-commissary facility shown)
-    const plusButtons = screen.getAllByText('+');
-    fireEvent.click(plusButtons[0]);
+    // Gym is the first facility shown (Row 1)
+    const quantityInputs = screen.getAllByLabelText('Quantity:');
+    fireEvent.change(quantityInputs[0], { target: { value: '1' } });
     expect(onUpdate).toHaveBeenCalledWith(
       expect.arrayContaining([expect.objectContaining({ facility_type: 'gym', quantity: 1 })])
     );
   });
 
-  it('+ button increments quantity for existing facility', () => {
+  it('typing a large quantity updates an existing facility directly, without one click per unit', () => {
     const onUpdate = jest.fn();
     const facilities: Facility[] = [
       { facility_type: 'commissary', quantity: 1, mass: 2, cost: 0.2 },
       { facility_type: 'gym', quantity: 1, mass: 3, cost: 0.1 }
     ];
     render(<FacilitiesPanel facilities={facilities} onUpdate={onUpdate} />);
-    const plusButtons = screen.getAllByText('+');
-    fireEvent.click(plusButtons[0]); // Gym is first in row 1
+    const quantityInputs = screen.getAllByLabelText('Quantity:'); // Gym is first in row 1
+    fireEvent.change(quantityInputs[0], { target: { value: '250' } });
     expect(onUpdate).toHaveBeenCalledWith(
-      expect.arrayContaining([expect.objectContaining({ facility_type: 'gym', quantity: 2 })])
+      expect.arrayContaining([expect.objectContaining({ facility_type: 'gym', quantity: 250 })])
     );
   });
 
-  it('- button decrements facility and removes at 0', () => {
+  it('typing 0 removes a facility', () => {
     const onUpdate = jest.fn();
     const facilities: Facility[] = [
       { facility_type: 'commissary', quantity: 1, mass: 2, cost: 0.2 },
       { facility_type: 'gym', quantity: 1, mass: 3, cost: 0.1 }
     ];
     render(<FacilitiesPanel facilities={facilities} onUpdate={onUpdate} />);
-    const minusButtons = screen.getAllByText('-');
-    // Find the enabled minus button for gym
-    const enabledMinus = minusButtons.find(btn => !btn.hasAttribute('disabled'));
-    fireEvent.click(enabledMinus!);
+    const quantityInputs = screen.getAllByLabelText('Quantity:');
+    fireEvent.change(quantityInputs[0], { target: { value: '0' } });
     const result = (onUpdate.mock.calls[0][0] as Facility[]);
     expect(result.some(f => f.facility_type === 'gym')).toBe(false);
   });
 
-  it('- button disabled when quantity is 0', () => {
+  it('treats a negative entry as zero', () => {
+    const onUpdate = jest.fn();
+    const facilities: Facility[] = [
+      { facility_type: 'commissary', quantity: 1, mass: 2, cost: 0.2 },
+      { facility_type: 'gym', quantity: 1, mass: 3, cost: 0.1 }
+    ];
+    render(<FacilitiesPanel facilities={facilities} onUpdate={onUpdate} />);
+    const quantityInputs = screen.getAllByLabelText('Quantity:');
+    fireEvent.change(quantityInputs[0], { target: { value: '-5' } });
+    const result = (onUpdate.mock.calls[0][0] as Facility[]);
+    expect(result.some(f => f.facility_type === 'gym')).toBe(false);
+  });
+
+  it('quantity inputs allow direct entry and have a minimum of 0', () => {
     const facilities: Facility[] = [{ facility_type: 'commissary', quantity: 1, mass: 2, cost: 0.2 }];
     render(<FacilitiesPanel facilities={facilities} onUpdate={noOp} />);
-    const minusButtons = screen.getAllByText('-');
-    // All - buttons for zero-quantity facilities should be disabled
-    const disabledCount = minusButtons.filter(btn => btn.hasAttribute('disabled')).length;
-    expect(disabledCount).toBeGreaterThan(0);
+    const quantityInputs = screen.getAllByLabelText('Quantity:');
+    expect(quantityInputs.length).toBeGreaterThan(0);
+    quantityInputs.forEach(input => {
+      expect(input).toHaveAttribute('type', 'number');
+      expect(input).toHaveAttribute('min', '0');
+    });
   });
 
   it('shows valid commissary requirement when commissary present', () => {

--- a/src/components/FacilitiesPanel.tsx
+++ b/src/components/FacilitiesPanel.tsx
@@ -24,32 +24,24 @@ const FacilitiesPanel: React.FC<FacilitiesPanelProps> = ({ facilities, onUpdate 
     }
   }, [hasCommissary, facilities, onUpdate]);
 
-  const addFacility = (facilityType: typeof FACILITY_TYPES[0]) => {
+  const updateFacilityQuantity = (facilityType: typeof FACILITY_TYPES[0], requestedQuantity: number) => {
+    const validQuantity = Math.max(0, Math.floor(requestedQuantity));
     const existingFacility = facilities.find(f => f.facility_type === facilityType.type);
-    if (existingFacility) {
-      const newFacilities = facilities.map(f =>
-        f.facility_type === facilityType.type
-          ? { ...f, quantity: f.quantity + 1 }
-          : f
-      );
-      onUpdate(newFacilities);
+
+    if (validQuantity === 0) {
+      onUpdate(facilities.filter(f => f.facility_type !== facilityType.type));
+    } else if (existingFacility) {
+      onUpdate(facilities.map(f =>
+        f.facility_type === facilityType.type ? { ...f, quantity: validQuantity } : f
+      ));
     } else {
       onUpdate([...facilities, {
         facility_type: facilityType.type as Facility['facility_type'],
-        quantity: 1,
+        quantity: validQuantity,
         mass: facilityType.mass,
         cost: facilityType.cost
       }]);
     }
-  };
-
-  const removeFacility = (facilityType: string) => {
-    const newFacilities = facilities.map(f =>
-      f.facility_type === facilityType
-        ? { ...f, quantity: Math.max(0, f.quantity - 1) }
-        : f
-    ).filter(f => f.quantity > 0);
-    onUpdate(newFacilities);
   };
 
   return (
@@ -70,18 +62,16 @@ const FacilitiesPanel: React.FC<FacilitiesPanelProps> = ({ facilities, onUpdate 
                   <h4>{facilityType.name}, {facilityType.mass} tons, {facilityType.cost} MCr</h4>
                 </div>
                 <div className="quantity-control">
-                  <button 
-                    onClick={() => removeFacility(facilityType.type)}
-                    disabled={quantity === 0}
-                  >
-                    -
-                  </button>
-                  <span>{quantity}</span>
-                  <button 
-                    onClick={() => addFacility(facilityType)}
-                  >
-                    +
-                  </button>
+                  <label>
+                    Quantity:
+                    <input
+                      type="number"
+                      min="0"
+                      value={quantity}
+                      onChange={(e) => updateFacilityQuantity(facilityType, parseInt(e.target.value) || 0)}
+                      style={{ width: '60px', marginLeft: '0.5rem' }}
+                    />
+                  </label>
                 </div>
               </div>
             );
@@ -100,18 +90,16 @@ const FacilitiesPanel: React.FC<FacilitiesPanelProps> = ({ facilities, onUpdate 
                   <h4>{facilityType.name}, {facilityType.mass} tons, {facilityType.cost} MCr</h4>
                 </div>
                 <div className="quantity-control">
-                  <button 
-                    onClick={() => removeFacility(facilityType.type)}
-                    disabled={quantity === 0}
-                  >
-                    -
-                  </button>
-                  <span>{quantity}</span>
-                  <button 
-                    onClick={() => addFacility(facilityType)}
-                  >
-                    +
-                  </button>
+                  <label>
+                    Quantity:
+                    <input
+                      type="number"
+                      min="0"
+                      value={quantity}
+                      onChange={(e) => updateFacilityQuantity(facilityType, parseInt(e.target.value) || 0)}
+                      style={{ width: '60px', marginLeft: '0.5rem' }}
+                    />
+                  </label>
                 </div>
               </div>
             );
@@ -130,18 +118,16 @@ const FacilitiesPanel: React.FC<FacilitiesPanelProps> = ({ facilities, onUpdate 
                   <h4>{facilityType.name}, {facilityType.mass} tons, {facilityType.cost} MCr</h4>
                 </div>
                 <div className="quantity-control">
-                  <button 
-                    onClick={() => removeFacility(facilityType.type)}
-                    disabled={quantity === 0}
-                  >
-                    -
-                  </button>
-                  <span>{quantity}</span>
-                  <button 
-                    onClick={() => addFacility(facilityType)}
-                  >
-                    +
-                  </button>
+                  <label>
+                    Quantity:
+                    <input
+                      type="number"
+                      min="0"
+                      value={quantity}
+                      onChange={(e) => updateFacilityQuantity(facilityType, parseInt(e.target.value) || 0)}
+                      style={{ width: '60px', marginLeft: '0.5rem' }}
+                    />
+                  </label>
                 </div>
               </div>
             );
@@ -160,18 +146,16 @@ const FacilitiesPanel: React.FC<FacilitiesPanelProps> = ({ facilities, onUpdate 
                   <h4>{facilityType.name}, {facilityType.mass} tons, {facilityType.cost} MCr</h4>
                 </div>
                 <div className="quantity-control">
-                  <button 
-                    onClick={() => removeFacility(facilityType.type)}
-                    disabled={quantity === 0}
-                  >
-                    -
-                  </button>
-                  <span>{quantity}</span>
-                  <button 
-                    onClick={() => addFacility(facilityType)}
-                  >
-                    +
-                  </button>
+                  <label>
+                    Quantity:
+                    <input
+                      type="number"
+                      min="0"
+                      value={quantity}
+                      onChange={(e) => updateFacilityQuantity(facilityType, parseInt(e.target.value) || 0)}
+                      style={{ width: '60px', marginLeft: '0.5rem' }}
+                    />
+                  </label>
                 </div>
               </div>
             );


### PR DESCRIPTION
## Summary
- Rec/Health (`FacilitiesPanel.tsx`) used one-click `-`/`+` buttons for facility quantity — one click per unit, no direct entry. Entering anything approaching a hundred of any facility was extremely tedious.
- Switched to a native `<input type="number">`: spinner arrows (press-and-hold rapid-increment) plus direct typed entry. This is the same pattern already used elsewhere in this app for Missile Reload Tonnage in `WeaponsPanel.tsx`.
- Note: this branch's `WeaponsPanel.tsx` still uses the old one-click button scheme for weapon *quantities* themselves (only Missile Reload Tonnage uses a number input) — that's a separate, larger change I did not make here, since the ask was specifically about Rec/Health's usability. Only `FacilitiesPanel` was touched.
- Replaced the delta-based `addFacility`/`removeFacility` (+1/-1 per click) with an absolute-value `updateFacilityQuantity()`, since the native input reports the target value directly rather than a step.
- Updated `FacilitiesPanel.test.tsx`'s quantity-control tests (typing a value / typing 0 to remove / negative clamps to 0) to match — the old tests asserted against `+`/`-` button clicks which no longer exist.
- No behavior change to the "Commissary is required" auto-add logic.

## Test plan
- [x] `pnpm lint` — 0 errors/warnings
- [x] `pnpm test:run` — 365/365 passing
- [x] `pnpm build` — succeeds
- [ ] Could not get a live browser screenshot in this environment (Chrome extension wasn't connected) — please give it a quick manual check in the Rec/Health panel before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXHBvdJ5mLZTWFRChrvkoU