### PR TITLE
Port custom crew tracking, Robotics rule, and TL-J to capital

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ Test files are co-located with source files using .test.ts/.test.tsx extension
 
 **Panel Flow**: Ship → Engines → Fittings → Weapons → Defenses → Rec/Health → Cargo → Vehicles → Drones → Custom → Berths → Staff → Ship Design
 
-**Note**: The Custom panel (index 9) was added to allow users to define custom items not in predefined lists.
+**Note**: The Custom panel (index 9) was added to allow users to define custom items not in predefined lists. Once at least one custom item exists, the panel also shows a "Custom Crew" section (`shipDesign.custom_crew`, type `CustomCrew`) with a number entry per crew category — the same 9 positions shown on the Staff panel, plus 4 (Infantry/Armor/MP/Security) that exist only as custom-crew entries. These counts add directly into `calculateStaffRequirements()`'s totals (see Staff Requirements Logic).
 
 ### Key Design Patterns
 
@@ -280,26 +280,29 @@ The `calculateMass()` function in App.tsx handles:
 
 Complex crew calculation in `calculateStaffRequirements()` (hoisted before JSX return in App.tsx, called once per render):
 - **Engineers**: Tiered by ship tonnage:
-  - 100 tons: fixed 1 engineer
-  - 200 or 300 tons: fixed 2 engineers
-  - 400+ tons: at least 1 per engine (`max(engineCount, 1)`), plus `ceil(mass/100) - 1` extra for each engine whose mass exceeds 100 tons
-  - Other sizes (fallback): `ceil(totalEnginesMass / 100)`
+  - 100 tons: fixed 1 engineer (not reduced by Robotics)
+  - 200 or 300 tons: fixed 2 engineers (not reduced by Robotics)
+  - 400+ tons (or any tonnage with at least one engine): 1 per engine, plus `ceil(mass/100) - 1` extra for each engine whose mass exceeds 100 tons; if the Robotics rule is active, each engine's own crew requirement (mass tier included) is divided by `getRoboticsCrewDivisor(techLevel)` and rounded up *before* summing across engines
+  - No engines configured: fixed 1 engineer (not reduced by Robotics)
 - **Gunners**:
   - 1 per 10 turrets/barbettes (rounded up)
   - 1 per 10 defense turrets (rounded up)
   - Defensive screens: minimum 4, or `ceil(totalScreenTons / 100)` if total screen tonnage >400
   - Spinal weapons: +10 gunners
   - Bay weapons: 2 gunners per bay weapon (per unit quantity)
+  - If the Robotics rule is active, the summed gunner total above is divided by `getRoboticsGunnerDivisor(techLevel)` and rounded up — one TL tier behind the engineer reduction (starts at TL-G, not TL-F)
 - **Stewards**: 1 per 8 staterooms (rounded up)
 - **Medical**: Calculated by `calculateMedicalStaff()` based on medical facilities
 - **Service**: Vehicle service (`calculateVehicleServiceStaff`) + drone service (`calculateDroneServiceStaff`) from `constants.ts`
+- **Custom Crew**: The Custom panel's per-category crew counts (`shipDesign.custom_crew`) are added on top of every formula-derived position above; `infantry`/`armor`/`mp`/`security` have no formula anywhere else, so their `StaffRequirements` totals are exactly whatever's entered there
 
 Small ships (**exactly** 100 or 200 tons — not 300+) can combine pilot/navigator roles and skip stewards.
 
 ### Tech Level Dependencies
 
 Many features are tech-level gated:
-- Maximum jump performance: TL A=J1, TL B=J2, ... TL F+=J6. With the Longer Jumps rule active, TL G allows J-8 and TL H allows J-10 (`getEffectiveMaxJump(techLevel, longerJumpsEnabled)`); power plants and maneuver drives can reach performance 10 to support those drives.
+- `TECH_LEVELS` runs `A`-`H`, then `J` (TL 18) — `I` is skipped per the Traveller TL convention, matching the letter-skip already used for capital-ship hull codes. `convertTechLevelToNumber()` derives its result from `TECH_LEVELS` position (`getTechLevelIndex(tl) + 10`), not raw character code, so the skip is handled correctly; don't revert it to a charCode formula.
+- Maximum jump performance: TL A=J1, TL B=J2, ... TL F+=J6. With the Longer Jumps rule active, TL G allows J-8 and TL H+ (including TL-J) allows J-10 (`getEffectiveMaxJump(techLevel, longerJumpsEnabled)`); power plants and maneuver drives can reach performance 10 to support those drives. TL-J doesn't currently unlock any jump/power-plant performance beyond what TL-H already gives — it exists to support the Robotics rule's TL-J tier (see Rules System) — so extending performance further at TL-J is a deliberate future addition, not an oversight.
 - Spinal weapons: Different weapons available at different TLs, require minimum power plant performance
 - Computer models: Minimum computer required based on tonnage + jump performance
 - Vehicle availability: Most vehicles have minimum TL requirements
@@ -321,6 +324,7 @@ Ships ≥3,000 tons are capital ships with special rules:
 - `'spacecraft_design_srd'`: Always enabled (base rules)
 - `'antimatter'`: Antimatter drives (TL-H, 1% of ship tons per Jump performance)
 - `'longer_jumps'`: Extended jumps (TL-G+) — raises the jump cap via `getEffectiveMaxJump()`
+- `'robotics'`: Robotic crew assistance (TL-F+) — reduces per-engine Engineer requirements via `getRoboticsCrewDivisor(techLevel)` (TL-F=1/2, TL-G=1/4, TL-H=1/6, TL-J=1/8) and, one TL tier later, total Gunner requirements via `getRoboticsGunnerDivisor(techLevel)` (TL-G=1/2, TL-H=1/3, TL-J=1/4). Both divisors are read directly in `calculateStaffRequirements()` — Robotics has no installed-component analog the way the Antimatter Plant does, it's a pure rules toggle
 - Additional rules can be added via RulesMenu component
 
 Rules affect calculations (e.g., fuel mass with antimatter) - check `activeRules.has('rule_id')` before applying rule-specific logic. `RulesMenu` computes `enabled`/`disabled` per-rule from the ship's tech level on every render, but that's purely for its own display — it must separately call `onRuleChange` whenever a tech-level change flips a rule's effective availability, or App's `activeRules` (the actual source of truth used in calculations) silently desyncs from what the menu shows.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, lazy, Suspense } from 'react';
 import type { Ship, ShipDesign, MassCalculation, CostCalculation, StaffRequirements } from './types/ship';
-import { calculateTotalFuelMass, calculateVehicleServiceStaff, calculateDroneServiceStaff, calculateMedicalStaff, convertTechLevelToNumber, getBridgeMassAndCost, getEffectiveMaxJump, getHullCost, getNumberOfSections, getMinimumComputer, COMPUTER_TYPES, VEHICLE_TYPES, WEAPON_TYPES, BAY_WEAPON_TYPES, getAvailableSpinalWeapons } from './data/constants';
+import { calculateTotalFuelMass, calculateVehicleServiceStaff, calculateDroneServiceStaff, calculateMedicalStaff, convertTechLevelToNumber, getBridgeMassAndCost, getEffectiveMaxJump, getHullCost, getNumberOfSections, getMinimumComputer, getRoboticsCrewDivisor, getRoboticsGunnerDivisor, COMPUTER_TYPES, VEHICLE_TYPES, WEAPON_TYPES, BAY_WEAPON_TYPES, getAvailableSpinalWeapons } from './data/constants';
 import { databaseService } from './services/database';
 import { logger } from './utils/logger';
 import { createEmptyShipDesign, createDefaultShip } from './utils/shipDefaults';
@@ -137,15 +137,18 @@ function App() {
       engineers = 1;
     } else if (shipTonnage === 200 || shipTonnage === 300) {
       engineers = 2;
+    } else if (shipDesign.engines.length === 0) {
+      engineers = 1;
     } else {
-      const engineCount = shipDesign.engines.length;
-      engineers = Math.max(engineCount, 1);
-
-      for (const engine of shipDesign.engines) {
-        if (engine.mass > 100) {
-          engineers += Math.ceil(engine.mass / 100) - 1;
-        }
-      }
+      // Robotics (TL-F+ Rules menu toggle) reduces each engine's own crew
+      // requirement, rounded up, applied per engine before summing.
+      const roboticsDivisor = activeRules.has('robotics')
+        ? getRoboticsCrewDivisor(shipDesign.ship.tech_level)
+        : 1;
+      engineers = shipDesign.engines.reduce((sum, engine) => {
+        const baseCrew = 1 + (engine.mass > 100 ? Math.ceil(engine.mass / 100) - 1 : 0);
+        return sum + Math.ceil(baseCrew / roboticsDivisor);
+      }, 0);
     }
 
     const bayWeaponNames = BAY_WEAPON_TYPES.map(b => b.name);
@@ -178,7 +181,13 @@ function App() {
     const bayWeapons = shipDesign.weapons.filter(w => bayWeaponNames.includes(w.weapon_name));
     const bayWeaponGunners = bayWeapons.reduce((sum, weapon) => sum + (weapon.quantity * 2), 0);
 
-    const gunners = turretsAndBarbettesGunners + defenseTurretGunners + screenGunners + spinalWeaponGunners + bayWeaponGunners;
+    const baseGunners = turretsAndBarbettesGunners + defenseTurretGunners + screenGunners + spinalWeaponGunners + bayWeaponGunners;
+    // Robotics also automates gunnery support, one tier behind the
+    // engineering reduction above (starts at TL-G, not TL-F).
+    const gunnerDivisor = activeRules.has('robotics')
+      ? getRoboticsGunnerDivisor(shipDesign.ship.tech_level)
+      : 1;
+    const gunners = Math.ceil(baseGunners / gunnerDivisor);
 
     const vehicleService = calculateVehicleServiceStaff(shipDesign.vehicles);
     const droneService = calculateDroneServiceStaff(shipDesign.drones);
@@ -190,12 +199,31 @@ function App() {
     const stewards = Math.ceil(totalStaterooms / 8);
 
     const medicalStaff = calculateMedicalStaff(shipDesign.facilities);
-    const { nurses, surgeons, techs } = medicalStaff;
+    const { nurses: baseNurses, surgeons: baseSurgeons, techs: baseTechs } = medicalStaff;
 
-    const total = pilot + navigator + engineers + gunners + service + stewards + nurses + surgeons + techs;
+    // Crew assigned to operate/service/repair/serve custom items adds onto
+    // the corresponding position; infantry/armor/mp/security have no
+    // baseline formula elsewhere, so they're purely custom-crew-driven.
+    const customCrew = shipDesign.custom_crew;
+    const pilotTotal = pilot + customCrew.pilot;
+    const navigatorTotal = navigator + customCrew.navigator;
+    const engineersTotal = engineers + customCrew.engineers;
+    const gunnersTotal = gunners + customCrew.gunners;
+    const serviceTotal = service + customCrew.service;
+    const stewardsTotal = stewards + customCrew.stewards;
+    const nurses = baseNurses + customCrew.nurses;
+    const surgeons = baseSurgeons + customCrew.surgeons;
+    const techs = baseTechs + customCrew.techs;
+    const { infantry, armor, mp, security } = customCrew;
 
-    return { pilot, navigator, engineers, gunners, service, stewards, nurses, surgeons, techs, total };
-  }, [shipDesign]);
+    const total = pilotTotal + navigatorTotal + engineersTotal + gunnersTotal + serviceTotal + stewardsTotal
+      + nurses + surgeons + techs + infantry + armor + mp + security;
+
+    return {
+      pilot: pilotTotal, navigator: navigatorTotal, engineers: engineersTotal, gunners: gunnersTotal,
+      service: serviceTotal, stewards: stewardsTotal, nurses, surgeons, techs, infantry, armor, mp, security, total
+    };
+  }, [shipDesign, activeRules]);
 
   const handleFileSave = useCallback(async () => {
     if (!shipDesign.ship.name.trim()) {
@@ -553,7 +581,12 @@ function App() {
       case 8:
         return <DronesPanel drones={shipDesign.drones} onUpdate={(drones) => updateShipDesign({ drones })} />;
       case 9:
-        return <CustomPanel custom_items={shipDesign.custom_items} onUpdate={(custom_items) => updateShipDesign({ custom_items })} />;
+        return <CustomPanel
+          custom_items={shipDesign.custom_items}
+          custom_crew={shipDesign.custom_crew}
+          onUpdate={(custom_items) => updateShipDesign({ custom_items })}
+          onCrewUpdate={(custom_crew) => updateShipDesign({ custom_crew })}
+        />;
       case 10:
         return <BerthsPanel
           berths={shipDesign.berths}

--- a/src/components/CustomPanel.test.tsx
+++ b/src/components/CustomPanel.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import '@testing-library/jest-dom';
+import CustomPanel from './CustomPanel';
+import type { CustomItem, CustomCrew } from '../types/ship';
+
+const emptyCrew: CustomCrew = {
+  pilot: 0, navigator: 0, engineers: 0, gunners: 0, service: 0, stewards: 0,
+  nurses: 0, surgeons: 0, techs: 0, infantry: 0, armor: 0, mp: 0, security: 0,
+};
+
+describe('CustomPanel custom crew section', () => {
+  const mockOnUpdate = jest.fn();
+  const mockOnCrewUpdate = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('hides the custom crew section when there are no custom items', () => {
+    render(<CustomPanel custom_items={[]} custom_crew={emptyCrew} onUpdate={mockOnUpdate} onCrewUpdate={mockOnCrewUpdate} />);
+    expect(screen.queryByText('Custom Crew')).not.toBeInTheDocument();
+  });
+
+  it('shows the custom crew section once a custom item has been added', () => {
+    const items: CustomItem[] = [{ name: 'Sensor Pod', mass: 5, cost: 2 }];
+    render(<CustomPanel custom_items={items} custom_crew={emptyCrew} onUpdate={mockOnUpdate} onCrewUpdate={mockOnCrewUpdate} />);
+    expect(screen.getByText('Custom Crew')).toBeInTheDocument();
+  });
+
+  it('shows a number entry for every crew category', () => {
+    const items: CustomItem[] = [{ name: 'Sensor Pod', mass: 5, cost: 2 }];
+    render(<CustomPanel custom_items={items} custom_crew={emptyCrew} onUpdate={mockOnUpdate} onCrewUpdate={mockOnCrewUpdate} />);
+    ['Pilot', 'Navigator', 'Engineers', 'Gunners', 'Service', 'Stewards', 'Nurses', 'Surgeons', 'Techs',
+      'Infantry', 'Armor', 'MP', 'Security'].forEach(label => {
+      expect(screen.getByLabelText(label)).toBeInTheDocument();
+    });
+  });
+
+  it('calls onCrewUpdate with the changed category when a crew count is edited', () => {
+    const items: CustomItem[] = [{ name: 'Sensor Pod', mass: 5, cost: 2 }];
+    render(<CustomPanel custom_items={items} custom_crew={emptyCrew} onUpdate={mockOnUpdate} onCrewUpdate={mockOnCrewUpdate} />);
+
+    fireEvent.change(screen.getByLabelText('Infantry'), { target: { value: '4' } });
+
+    expect(mockOnCrewUpdate).toHaveBeenCalledWith({ ...emptyCrew, infantry: 4 });
+  });
+
+  it('preserves other category counts when one is changed', () => {
+    const items: CustomItem[] = [{ name: 'Sensor Pod', mass: 5, cost: 2 }];
+    const crew: CustomCrew = { ...emptyCrew, security: 2 };
+    render(<CustomPanel custom_items={items} custom_crew={crew} onUpdate={mockOnUpdate} onCrewUpdate={mockOnCrewUpdate} />);
+
+    fireEvent.change(screen.getByLabelText('MP'), { target: { value: '3' } });
+
+    expect(mockOnCrewUpdate).toHaveBeenCalledWith({ ...crew, mp: 3 });
+  });
+
+  it('treats a negative or invalid entry as zero', () => {
+    const items: CustomItem[] = [{ name: 'Sensor Pod', mass: 5, cost: 2 }];
+    render(<CustomPanel custom_items={items} custom_crew={emptyCrew} onUpdate={mockOnUpdate} onCrewUpdate={mockOnCrewUpdate} />);
+
+    fireEvent.change(screen.getByLabelText('Armor'), { target: { value: '-5' } });
+
+    expect(mockOnCrewUpdate).toHaveBeenCalledWith({ ...emptyCrew, armor: 0 });
+  });
+});

--- a/src/components/CustomPanel.tsx
+++ b/src/components/CustomPanel.tsx
@@ -1,12 +1,15 @@
 import React, { useState } from 'react';
-import type { CustomItem } from '../types/ship';
+import type { CustomItem, CustomCrew } from '../types/ship';
+import { CUSTOM_CREW_CATEGORIES } from '../data/constants';
 
 interface CustomPanelProps {
   custom_items: CustomItem[];
+  custom_crew: CustomCrew;
   onUpdate: (custom_items: CustomItem[]) => void;
+  onCrewUpdate: (custom_crew: CustomCrew) => void;
 }
 
-const CustomPanel: React.FC<CustomPanelProps> = ({ custom_items, onUpdate }) => {
+const CustomPanel: React.FC<CustomPanelProps> = ({ custom_items, custom_crew, onUpdate, onCrewUpdate }) => {
   const [newItemName, setNewItemName] = useState('');
   const [newItemMass, setNewItemMass] = useState('');
   const [newItemCost, setNewItemCost] = useState('');
@@ -41,6 +44,11 @@ const CustomPanel: React.FC<CustomPanelProps> = ({ custom_items, onUpdate }) => 
   const handleRemoveItem = (index: number) => {
     const newItems = custom_items.filter((_, i) => i !== index);
     onUpdate(newItems);
+  };
+
+  const handleCrewChange = (key: keyof CustomCrew, value: string) => {
+    const count = Math.max(0, parseInt(value, 10) || 0);
+    onCrewUpdate({ ...custom_crew, [key]: count });
   };
 
   const totalMass = custom_items.reduce((sum, item) => sum + item.mass, 0);
@@ -132,6 +140,28 @@ const CustomPanel: React.FC<CustomPanelProps> = ({ custom_items, onUpdate }) => 
           </>
         )}
       </div>
+
+      {custom_items.length > 0 && (
+        <div className="custom-crew">
+          <h3>Custom Crew</h3>
+          <p>Crew to operate, service, repair, and serve the custom items above. Added to the ship's total Staff Requirements.</p>
+          <div className="form-row">
+            {CUSTOM_CREW_CATEGORIES.map(({ key, label }) => (
+              <div key={key} className="form-group">
+                <label htmlFor={`custom-crew-${key}`}>{label}</label>
+                <input
+                  id={`custom-crew-${key}`}
+                  type="number"
+                  step="1"
+                  min="0"
+                  value={custom_crew[key]}
+                  onChange={(e) => handleCrewChange(key, e.target.value)}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/RulesMenu.test.tsx
+++ b/src/components/RulesMenu.test.tsx
@@ -140,6 +140,75 @@ describe('RulesMenu Tech Level Restrictions', () => {
     });
   });
 
+  describe('Robotics Tech Level Restrictions', () => {
+    it('should disable Robotics for TL A ship', () => {
+      const shipDesign = createMockShipDesign('A');
+      render(<RulesMenu shipDesign={shipDesign} onRuleChange={mockOnRuleChange} />);
+
+      fireEvent.click(screen.getByText('Rules'));
+
+      const roboticsItem = screen.getByText('Robotics').closest('button');
+
+      expect(roboticsItem?.classList.contains('disabled')).toBe(true);
+    });
+
+    it('should disable Robotics for TL E ship', () => {
+      const shipDesign = createMockShipDesign('E');
+      render(<RulesMenu shipDesign={shipDesign} onRuleChange={mockOnRuleChange} />);
+
+      fireEvent.click(screen.getByText('Rules'));
+
+      const roboticsItem = screen.getByText('Robotics').closest('button');
+
+      expect(roboticsItem?.classList.contains('disabled')).toBe(true);
+    });
+
+    it('should enable Robotics for TL F ship', () => {
+      const shipDesign = createMockShipDesign('F');
+      render(<RulesMenu shipDesign={shipDesign} onRuleChange={mockOnRuleChange} />);
+
+      fireEvent.click(screen.getByText('Rules'));
+
+      const roboticsItem = screen.getByText('Robotics').closest('button');
+
+      expect(roboticsItem?.classList.contains('disabled')).toBe(false);
+    });
+
+    it('should allow toggling Robotics for TL F ship', () => {
+      const shipDesign = createMockShipDesign('F');
+      render(<RulesMenu shipDesign={shipDesign} onRuleChange={mockOnRuleChange} />);
+
+      fireEvent.click(screen.getByText('Rules'));
+
+      const roboticsItem = screen.getByText('Robotics').closest('button');
+      fireEvent.click(roboticsItem!);
+
+      expect(mockOnRuleChange).toHaveBeenCalledWith('robotics', true);
+    });
+
+    it('should not allow toggling Robotics for TL E ship', () => {
+      const shipDesign = createMockShipDesign('E');
+      render(<RulesMenu shipDesign={shipDesign} onRuleChange={mockOnRuleChange} />);
+
+      fireEvent.click(screen.getByText('Rules'));
+
+      const roboticsItem = screen.getByText('Robotics').closest('button');
+      fireEvent.click(roboticsItem!);
+
+      expect(mockOnRuleChange).not.toHaveBeenCalled();
+    });
+
+    it('should show tooltip for Robotics tech level restriction', () => {
+      const shipDesign = createMockShipDesign('E');
+      render(<RulesMenu shipDesign={shipDesign} onRuleChange={mockOnRuleChange} />);
+
+      fireEvent.click(screen.getByText('Rules'));
+
+      const roboticsIcon = screen.getByText('Robotics').closest('button')?.querySelector('.rule-status.disabled');
+      expect(roboticsIcon?.getAttribute('title')).toBe('Requires Tech Level F (current: E)');
+    });
+  });
+
   describe('Always Available Rules', () => {
     it('should always show Spacecraft Design SRD as enabled', () => {
       const shipDesign = createMockShipDesign('A');

--- a/src/components/RulesMenu.tsx
+++ b/src/components/RulesMenu.tsx
@@ -23,7 +23,8 @@ const RulesMenu: React.FC<RulesMenuProps> = ({ shipDesign, onRuleChange }) => {
   const currentTechLevel = shipDesign.ship.tech_level;
   const canUseAntimatter = isTechLevelAtLeast(currentTechLevel, 'H');
   const canUseLongerJumps = isTechLevelAtLeast(currentTechLevel, 'G');
-  
+  const canUseRobotics = isTechLevelAtLeast(currentTechLevel, 'F');
+
   const [enabledRuleIds, setEnabledRuleIds] = useState<Set<string>>(
     new Set(['spacecraft_design_srd'])
   );
@@ -66,6 +67,16 @@ const RulesMenu: React.FC<RulesMenuProps> = ({ shipDesign, onRuleChange }) => {
     onRuleChange?.('longer_jumps', longerJumpsEffective);
   }, [canUseLongerJumps, onRuleChange]);
 
+  const isFirstRoboticsCheck = useRef(true);
+  useEffect(() => {
+    if (isFirstRoboticsCheck.current) {
+      isFirstRoboticsCheck.current = false;
+      return;
+    }
+    const roboticsEffective = enabledRuleIdsRef.current.has('robotics') && canUseRobotics;
+    onRuleChange?.('robotics', roboticsEffective);
+  }, [canUseRobotics, onRuleChange]);
+
   // Derive full rule list each render; tech-level constraints are computed inline
   // so no useEffect is needed to sync disabled state.
   const rules: RuleItem[] = [
@@ -77,6 +88,9 @@ const RulesMenu: React.FC<RulesMenuProps> = ({ shipDesign, onRuleChange }) => {
     { id: 'longer_jumps', name: 'Longer Jumps',
       enabled: enabledRuleIds.has('longer_jumps') && canUseLongerJumps,
       disabled: !canUseLongerJumps },
+    { id: 'robotics', name: 'Robotics',
+      enabled: enabledRuleIds.has('robotics') && canUseRobotics,
+      disabled: !canUseRobotics },
   ];
 
   const toggleRule = (ruleId: string) => {
@@ -106,6 +120,8 @@ const RulesMenu: React.FC<RulesMenuProps> = ({ shipDesign, onRuleChange }) => {
         return <span className="rule-status disabled" title={`Requires Tech Level H (current: ${currentTechLevel})`}>—</span>;
       } else if (rule.id === 'longer_jumps' && !canUseLongerJumps) {
         return <span className="rule-status disabled" title={`Requires Tech Level G+ (current: ${currentTechLevel})`}>—</span>;
+      } else if (rule.id === 'robotics' && !canUseRobotics) {
+        return <span className="rule-status disabled" title={`Requires Tech Level F (current: ${currentTechLevel})`}>—</span>;
       }
       return <span className="rule-status disabled">—</span>;
     }

--- a/src/components/SelectShipPanel.tsx
+++ b/src/components/SelectShipPanel.tsx
@@ -3,6 +3,7 @@ import { databaseService, type StoredShipDesign } from '../services/database';
 import { initialDataService } from '../services/initialDataService';
 import type { ShipDesign } from '../types/ship';
 import { logger } from '../utils/logger';
+import { createEmptyCustomCrew } from '../utils/shipDefaults';
 
 interface SelectShipPanelProps {
   onNewShip: () => void;
@@ -87,6 +88,7 @@ function createDefaultShips() {
         { name: 'ATLAS Combat Droid', mass: 1, cost: 0.025 },
         { name: 'ATLAS Combat Droid', mass: 1, cost: 0.025 }
       ],
+      custom_crew: createEmptyCustomCrew(),
       createdAt: new Date(),
       updatedAt: new Date()
     };
@@ -171,6 +173,7 @@ function createDefaultShips() {
         mass: 1,
         cost: 0.024
       })),
+      custom_crew: createEmptyCustomCrew(),
       createdAt: new Date(),
       updatedAt: new Date()
     };

--- a/src/components/ShipPanel.tsx
+++ b/src/components/ShipPanel.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import type { Ship, ShipDesign } from '../types/ship';
 import { TECH_LEVELS, HULL_SIZES, getTonnageCode, getNumberOfSections } from '../data/constants';
 import { databaseService } from '../services/database';
+import { createEmptyCustomCrew } from '../utils/shipDefaults';
 
 interface ShipPanelProps {
   ship: Ship;
@@ -57,7 +58,8 @@ const ShipPanel: React.FC<ShipPanelProps> = ({ ship, onUpdate, onLoadExistingShi
             cargo: existingShip.cargo,
             vehicles: existingShip.vehicles,
             drones: existingShip.drones,
-            custom_items: existingShip.custom_items || []
+            custom_items: existingShip.custom_items || [],
+            custom_crew: existingShip.custom_crew || createEmptyCustomCrew()
           }
         });
       } else {

--- a/src/components/StaffPanel.tsx
+++ b/src/components/StaffPanel.tsx
@@ -89,6 +89,10 @@ const StaffPanel: React.FC<StaffPanelProps> = ({
         <p>Nurses: {staffRequirements.nurses}</p>
         <p>Surgeons: {staffRequirements.surgeons}</p>
         <p>Techs: {staffRequirements.techs}</p>
+        {staffRequirements.infantry > 0 && <p>Infantry: {staffRequirements.infantry}</p>}
+        {staffRequirements.armor > 0 && <p>Armor: {staffRequirements.armor}</p>}
+        {staffRequirements.mp > 0 && <p>MP: {staffRequirements.mp}</p>}
+        {staffRequirements.security > 0 && <p>Security: {staffRequirements.security}</p>}
         <p><strong>Total Staff: {actualCrewCount}</strong></p>
       </div>
 

--- a/src/components/SummaryPanel.tsx
+++ b/src/components/SummaryPanel.tsx
@@ -621,6 +621,10 @@ const SummaryPanel: React.FC<SummaryPanelProps> = ({ shipDesign, mass, cost, sta
         {staff.nurses > 0 && <p><strong>Nurses:</strong> {staff.nurses}</p>}
         {staff.surgeons > 0 && <p><strong>Surgeons:</strong> {staff.surgeons}</p>}
         {staff.techs > 0 && <p><strong>Medical Techs:</strong> {staff.techs}</p>}
+        {staff.infantry > 0 && <p><strong>Infantry:</strong> {staff.infantry}</p>}
+        {staff.armor > 0 && <p><strong>Armor:</strong> {staff.armor}</p>}
+        {staff.mp > 0 && <p><strong>MP:</strong> {staff.mp}</p>}
+        {staff.security > 0 && <p><strong>Security:</strong> {staff.security}</p>}
         <p><strong>Total:</strong> {
           combinePilotNavigator && noStewards
             ? staff.total - 1 - staff.stewards

--- a/src/data/constants.test.ts
+++ b/src/data/constants.test.ts
@@ -11,6 +11,8 @@ import {
   convertTechLevelToNumber,
   getAvailableVehicles,
   getMinimumComputer,
+  getRoboticsCrewDivisor,
+  getRoboticsGunnerDivisor,
 } from './constants';
 
 describe('Tech Level Functions', () => {
@@ -24,6 +26,7 @@ describe('Tech Level Functions', () => {
       expect(getTechLevelIndex('F')).toBe(5);
       expect(getTechLevelIndex('G')).toBe(6);
       expect(getTechLevelIndex('H')).toBe(7);
+      expect(getTechLevelIndex('J')).toBe(8);
     });
 
     it('should return -1 for invalid tech levels', () => {
@@ -66,6 +69,33 @@ describe('Tech Level Functions', () => {
       expect(isTechLevelAtLeast('G', 'G')).toBe(true); // TL G can use longer jumps
       expect(isTechLevelAtLeast('F', 'G')).toBe(false); // TL F cannot use longer jumps
       expect(isTechLevelAtLeast('A', 'G')).toBe(false); // TL A cannot use longer jumps
+    });
+  });
+
+  describe('getRoboticsCrewDivisor', () => {
+    it('should return 1 below TL-F (no reduction)', () => {
+      expect(getRoboticsCrewDivisor('A')).toBe(1);
+      expect(getRoboticsCrewDivisor('E')).toBe(1);
+    });
+
+    it('should return the correct divisor at TL-F through TL-J', () => {
+      expect(getRoboticsCrewDivisor('F')).toBe(2);
+      expect(getRoboticsCrewDivisor('G')).toBe(4);
+      expect(getRoboticsCrewDivisor('H')).toBe(6);
+      expect(getRoboticsCrewDivisor('J')).toBe(8);
+    });
+  });
+
+  describe('getRoboticsGunnerDivisor', () => {
+    it('should return 1 below TL-G (no reduction, including TL-F)', () => {
+      expect(getRoboticsGunnerDivisor('A')).toBe(1);
+      expect(getRoboticsGunnerDivisor('F')).toBe(1);
+    });
+
+    it('should return the correct divisor at TL-G through TL-J', () => {
+      expect(getRoboticsGunnerDivisor('G')).toBe(2);
+      expect(getRoboticsGunnerDivisor('H')).toBe(3);
+      expect(getRoboticsGunnerDivisor('J')).toBe(4);
     });
   });
 });
@@ -346,9 +376,14 @@ describe('convertTechLevelToNumber', () => {
     expect(convertTechLevelToNumber('H')).toBe(17);
   });
 
-  it('should map any A-Z letter to charCode offset + 10', () => {
-    // 'Z' is a valid single uppercase letter so returns 35, not 0
-    expect(convertTechLevelToNumber('Z')).toBe(35);
+  it('should map J to 18, skipping I per the Traveller TL convention', () => {
+    expect(convertTechLevelToNumber('J')).toBe(18);
+  });
+
+  it('should return 0 for a letter not in TECH_LEVELS', () => {
+    // 'Z' is not (yet) a supported tech level, unlike the old charCode-offset
+    // formula which treated any single uppercase letter as valid.
+    expect(convertTechLevelToNumber('Z')).toBe(0);
   });
 
   it('should return 0 for empty string', () => {

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -1,6 +1,27 @@
-import type { Cargo } from '../types/ship';
+import type { Cargo, CustomCrew } from '../types/ship';
 
-export const TECH_LEVELS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
+// Crew categories shown on the Custom panel's crew-tracking section, in
+// display order - the same positions shown on the Staff panel, plus four
+// (infantry/armor/mp/security) that only exist as custom-crew entries.
+export const CUSTOM_CREW_CATEGORIES: { key: keyof CustomCrew; label: string }[] = [
+  { key: 'pilot', label: 'Pilot' },
+  { key: 'navigator', label: 'Navigator' },
+  { key: 'engineers', label: 'Engineers' },
+  { key: 'gunners', label: 'Gunners' },
+  { key: 'service', label: 'Service' },
+  { key: 'stewards', label: 'Stewards' },
+  { key: 'nurses', label: 'Nurses' },
+  { key: 'surgeons', label: 'Surgeons' },
+  { key: 'techs', label: 'Techs' },
+  { key: 'infantry', label: 'Infantry' },
+  { key: 'armor', label: 'Armor' },
+  { key: 'mp', label: 'MP' },
+  { key: 'security', label: 'Security' },
+];
+
+// TL letters skip 'I' (visual confusion with the digit 1), matching the
+// Traveller convention: ...H=17, I skipped, J=18, K=19...
+export const TECH_LEVELS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J'];
 
 export function getTechLevelIndex(techLevel: string): number {
   return TECH_LEVELS.indexOf(techLevel);
@@ -16,6 +37,29 @@ export function isTechLevelAtLeast(currentLevel: string, requiredLevel: string):
   }
 
   return currentIndex >= requiredIndex;
+}
+
+// Robotics (TL-F+, toggled via the Rules menu): robot workers assist each
+// engineer, letting them cover more of an engine's own crew requirement as
+// tech level improves. Divisor to apply (rounded up) to each engine's crew:
+// TL-F=1/2, TL-G=1/4, TL-H=1/6, TL-J=1/8. Below TL-F, no reduction (1).
+export function getRoboticsCrewDivisor(techLevel: string): number {
+  if (isTechLevelAtLeast(techLevel, 'J')) return 8;
+  if (isTechLevelAtLeast(techLevel, 'H')) return 6;
+  if (isTechLevelAtLeast(techLevel, 'G')) return 4;
+  if (isTechLevelAtLeast(techLevel, 'F')) return 2;
+  return 1;
+}
+
+// Robotics also automates gunnery support, one tier behind the engineering
+// reduction above (starts at TL-G, not TL-F): divisor to apply (rounded up)
+// to the ship's total gunner requirement. TL-G=1/2, TL-H=1/3, TL-J=1/4.
+// Below TL-G, no reduction (1).
+export function getRoboticsGunnerDivisor(techLevel: string): number {
+  if (isTechLevelAtLeast(techLevel, 'J')) return 4;
+  if (isTechLevelAtLeast(techLevel, 'H')) return 3;
+  if (isTechLevelAtLeast(techLevel, 'G')) return 2;
+  return 1;
 }
 
 // Calculate maximum jump performance based on tech level
@@ -666,9 +710,11 @@ export function getWeaponMountLimit(shipTonnage: number): number {
 }
 
 export function convertTechLevelToNumber(techLevel: string): number {
-  // Convert A=10, B=11, C=12, etc.
-  if (techLevel.length === 1 && techLevel >= 'A' && techLevel <= 'Z') {
-    return techLevel.charCodeAt(0) - 'A'.charCodeAt(0) + 10;
+  // Derive from TECH_LEVELS position (not raw char code) so the numbering
+  // stays correct now that 'I' is skipped: H=17, J=18, K=19, ...
+  const index = getTechLevelIndex(techLevel);
+  if (index !== -1) {
+    return index + 10;
   }
   return parseInt(techLevel) || 0;
 }

--- a/src/types/ship.ts
+++ b/src/types/ship.ts
@@ -94,6 +94,26 @@ export interface CustomItem {
   cost: number;
 }
 
+// Crew assigned specifically to operate/service/repair/serve custom items.
+// Uses the same position categories as StaffRequirements, plus four that
+// have no other source in this app (infantry/armor/mp/security have no
+// baseline formula elsewhere - they're purely custom-crew-driven).
+export interface CustomCrew {
+  pilot: number;
+  navigator: number;
+  engineers: number;
+  gunners: number;
+  service: number;
+  stewards: number;
+  nurses: number;
+  surgeons: number;
+  techs: number;
+  infantry: number;
+  armor: number;
+  mp: number;
+  security: number;
+}
+
 export interface StaffRequirements {
   pilot: number;
   navigator: number;
@@ -104,6 +124,10 @@ export interface StaffRequirements {
   nurses: number;
   surgeons: number;
   techs: number;
+  infantry: number;
+  armor: number;
+  mp: number;
+  security: number;
   total: number;
 }
 
@@ -119,6 +143,7 @@ export interface ShipDesign {
   vehicles: Vehicle[];
   drones: Drone[];
   custom_items: CustomItem[];
+  custom_crew: CustomCrew;
 }
 
 export interface MassCalculation {

--- a/src/utils/printContent.test.ts
+++ b/src/utils/printContent.test.ts
@@ -6,7 +6,8 @@ const baseMass: MassCalculation = { total: 200, used: 120, remaining: 80, isOver
 const baseCost: CostCalculation = { total: 45.5 };
 const baseStaff: StaffRequirements = {
   pilot: 1, navigator: 1, engineers: 2, gunners: 0,
-  service: 0, stewards: 0, nurses: 0, surgeons: 0, techs: 0, total: 4,
+  service: 0, stewards: 0, nurses: 0, surgeons: 0, techs: 0,
+  infantry: 0, armor: 0, mp: 0, security: 0, total: 4,
 };
 const baseRules = new Set(['spacecraft_design_srd']);
 
@@ -38,6 +39,10 @@ const baseShip: ShipDesign = {
   vehicles: [],
   drones: [],
   custom_items: [],
+  custom_crew: {
+    pilot: 0, navigator: 0, engineers: 0, gunners: 0, service: 0, stewards: 0,
+    nurses: 0, surgeons: 0, techs: 0, infantry: 0, armor: 0, mp: 0, security: 0,
+  },
 };
 
 describe('generateShipPrintContent', () => {
@@ -236,5 +241,22 @@ describe('generateShipPrintContent', () => {
     expect(html).toContain('Nurses');
     expect(html).toContain('Surgeons');
     expect(html).toContain('Medical Techs');
+  });
+
+  it('should hide custom crew rows (infantry/armor/mp/security) when zero', () => {
+    const html = generateShipPrintContent(baseShip, baseMass, baseCost, baseStaff, false, false, baseRules);
+    expect(html).not.toContain('Infantry');
+    expect(html).not.toContain('Armor');
+    expect(html).not.toContain('>MP:<');
+    expect(html).not.toContain('Security');
+  });
+
+  it('should show custom crew rows (infantry/armor/mp/security) only when present', () => {
+    const staffWithCustomCrew = { ...baseStaff, infantry: 4, armor: 2, mp: 1, security: 3, total: 20 };
+    const html = generateShipPrintContent(baseShip, baseMass, baseCost, staffWithCustomCrew, false, false, baseRules);
+    expect(html).toContain('Infantry');
+    expect(html).toContain('Armor');
+    expect(html).toContain('>MP:<');
+    expect(html).toContain('Security');
   });
 });

--- a/src/utils/printContent.ts
+++ b/src/utils/printContent.ts
@@ -205,6 +205,10 @@ export function generateShipPrintContent(
   if (staff.nurses > 0) crewLines.push(`<p><strong>Nurses:</strong> ${staff.nurses}</p>`);
   if (staff.surgeons > 0) crewLines.push(`<p><strong>Surgeons:</strong> ${staff.surgeons}</p>`);
   if (staff.techs > 0) crewLines.push(`<p><strong>Medical Techs:</strong> ${staff.techs}</p>`);
+  if (staff.infantry > 0) crewLines.push(`<p><strong>Infantry:</strong> ${staff.infantry}</p>`);
+  if (staff.armor > 0) crewLines.push(`<p><strong>Armor:</strong> ${staff.armor}</p>`);
+  if (staff.mp > 0) crewLines.push(`<p><strong>MP:</strong> ${staff.mp}</p>`);
+  if (staff.security > 0) crewLines.push(`<p><strong>Security:</strong> ${staff.security}</p>`);
   crewLines.push(`<p><strong>Total Crew:</strong> ${adjustedTotal}</p>`);
 
   const nonStandardNotice = shipDesign.ship.tonnage < 3000

--- a/src/utils/shipDefaults.ts
+++ b/src/utils/shipDefaults.ts
@@ -1,5 +1,21 @@
-import type { ShipDesign, Ship } from '../types/ship';
+import type { ShipDesign, Ship, CustomCrew } from '../types/ship';
 import { getNumberOfSections } from '../data/constants';
+
+export const createEmptyCustomCrew = (): CustomCrew => ({
+  pilot: 0,
+  navigator: 0,
+  engineers: 0,
+  gunners: 0,
+  service: 0,
+  stewards: 0,
+  nurses: 0,
+  surgeons: 0,
+  techs: 0,
+  infantry: 0,
+  armor: 0,
+  mp: 0,
+  security: 0
+});
 
 export const createEmptyShipDesign = (shipInfo: Ship): ShipDesign => {
   return {
@@ -20,7 +36,8 @@ export const createEmptyShipDesign = (shipInfo: Ship): ShipDesign => {
     cargo: [],
     vehicles: [],
     drones: [],
-    custom_items: []
+    custom_items: [],
+    custom_crew: createEmptyCustomCrew()
   };
 };
 


### PR DESCRIPTION
## Summary
Ports two features already on `megastructure` to `capital`, plus a new extension:

- **Custom panel crew tracking**: once a custom item exists, shows a "Custom Crew" section with a number entry per position (the 9 on the Staff panel, plus Infantry/Armor/MP/Security which have no other source). Counts add directly into `calculateStaffRequirements()`'s totals via a new `CustomCrew` type on `ShipDesign`.
- **Robotics rule** (TL-F+, Rules menu toggle): reduces each engine's own crew requirement, rounded up per engine before summing (`getRoboticsCrewDivisor`: TL-F=1/2, TL-G=1/4, TL-H=1/6, TL-J=1/8).
- **TL-J support**: capital topped out at TL-H; added `'J'` to `TECH_LEVELS`. This also surfaced a latent bug — `convertTechLevelToNumber()` used raw char-code arithmetic (`charCodeAt - 'A' + 10`), which puts TL-J one level too high (19 instead of 18) now that `'I'` is skipped per the Traveller convention. Fixed it to derive from `TECH_LEVELS` position instead (matches the fix already on `megastructure`). This affects spinal weapon TL-bonus tiers and vehicle TL-availability checks, so it needed fixing before TL-J could be trusted for anything.
- **New, not on megastructure**: a second Robotics factor that automates gunnery support one TL tier behind the engineering reduction — `getRoboticsGunnerDivisor`: TL-G=1/2, TL-H=1/3, TL-J=1/4 (no reduction at TL-F), applied to the ship's total gunner requirement and rounded up.

## Test plan
- [x] `pnpm build` — succeeds
- [x] `pnpm lint` — clean
- [x] `pnpm test:run` — 208/208 passing (added `CustomPanel.test.tsx`, Robotics tests in `RulesMenu.test.tsx`, divisor tests in `constants.test.ts`, and custom-crew-row tests in `printContent.test.ts`)
- [ ] Manual UI check — no browser available in this environment to screenshot the new Custom Crew section or Robotics rule toggle; please verify visually before merging

Claude-Session: https://claude.ai/code/session_01DXHBvdJ5mLZTWFRChrvkoU