### PR TITLE
Extend defensive screen TL limits through TL-G/H/J

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,6 +306,7 @@ Many features are tech-level gated:
 - Spinal weapons: Different weapons available at different TLs, require minimum power plant performance
 - Computer models: Minimum computer required based on tonnage + jump performance
 - Vehicle availability: Most vehicles have minimum TL requirements
+- Defensive screen quantity (`getMaxScreens()`, `SCREEN_TL_LIMITS` in `constants.ts`): Nuclear Damper and Meson Screen scale TL-C through TL-J (1/1, 2/2, 4/4, 6/6, 8/8, 10/9, 12/10 respectively); Black Globe unlocks at TL-F and scales TL-F through TL-J (3, 4, 6, 7). Per-unit mass/cost for all three instead scales with hull size (`getScreenSpecs()`, `SCREEN_SPECS_BY_HULL`), not TL.
 - Changing hull size (`handleShipInfoUpdate` in App.tsx) clears engine and fuel selections — engine mass/cost are computed from tonnage at selection time and don't auto-update — and re-tiers the bridge fitting. Changing tech level drops now-illegal jump drives and too-advanced vehicles from the design.
 
 Use helper functions: `isTechLevelAtLeast()`, `getMaxJumpByTechLevel()`, `getEffectiveMaxJump()`, `getTechLevelIndex()`

--- a/src/data/constants.test.ts
+++ b/src/data/constants.test.ts
@@ -13,6 +13,7 @@ import {
   getMinimumComputer,
   getRoboticsCrewDivisor,
   getRoboticsGunnerDivisor,
+  getMaxScreens,
 } from './constants';
 
 describe('Tech Level Functions', () => {
@@ -97,6 +98,42 @@ describe('Tech Level Functions', () => {
       expect(getRoboticsGunnerDivisor('H')).toBe(3);
       expect(getRoboticsGunnerDivisor('J')).toBe(4);
     });
+  });
+});
+
+describe('getMaxScreens', () => {
+  it('should return 0 below TL-C for nuclear dampers and meson screens', () => {
+    expect(getMaxScreens('nuclear_damper', 'B')).toBe(0);
+    expect(getMaxScreens('meson_screen', 'B')).toBe(0);
+  });
+
+  it('should scale nuclear dampers and meson screens from TL-C through TL-J', () => {
+    expect(getMaxScreens('nuclear_damper', 'C')).toBe(1);
+    expect(getMaxScreens('nuclear_damper', 'D')).toBe(2);
+    expect(getMaxScreens('nuclear_damper', 'E')).toBe(4);
+    expect(getMaxScreens('nuclear_damper', 'F')).toBe(6);
+    expect(getMaxScreens('nuclear_damper', 'G')).toBe(8);
+    expect(getMaxScreens('nuclear_damper', 'H')).toBe(10);
+    expect(getMaxScreens('nuclear_damper', 'J')).toBe(12);
+
+    expect(getMaxScreens('meson_screen', 'C')).toBe(1);
+    expect(getMaxScreens('meson_screen', 'D')).toBe(2);
+    expect(getMaxScreens('meson_screen', 'E')).toBe(4);
+    expect(getMaxScreens('meson_screen', 'F')).toBe(6);
+    expect(getMaxScreens('meson_screen', 'G')).toBe(8);
+    expect(getMaxScreens('meson_screen', 'H')).toBe(9);
+    expect(getMaxScreens('meson_screen', 'J')).toBe(10);
+  });
+
+  it('should return 0 for black globes below TL-F', () => {
+    expect(getMaxScreens('black_globe', 'E')).toBe(0);
+  });
+
+  it('should scale black globes from TL-F through TL-J', () => {
+    expect(getMaxScreens('black_globe', 'F')).toBe(3);
+    expect(getMaxScreens('black_globe', 'G')).toBe(4);
+    expect(getMaxScreens('black_globe', 'H')).toBe(6);
+    expect(getMaxScreens('black_globe', 'J')).toBe(7);
   });
 });
 

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -484,11 +484,11 @@ export const DEFENSE_TYPES = [
   { name: 'Dual Point Defense Laser Turret', type: 'dual_point_defense_laser_turret', mass: 1, cost: 1.5 }
 ];
 
-// Screen types with TL-based quantity limits
+// Screen types with TL-based quantity limits. TL 16/17/18 = G/H/J.
 export const SCREEN_TL_LIMITS = {
-  nuclear_damper: { 12: 1, 13: 2, 14: 4, 15: 6 },
-  meson_screen: { 12: 1, 13: 2, 14: 4, 15: 6 },
-  black_globe: { 15: 3 }
+  nuclear_damper: { 12: 1, 13: 2, 14: 4, 15: 6, 16: 8, 17: 10, 18: 12 },
+  meson_screen: { 12: 1, 13: 2, 14: 4, 15: 6, 16: 8, 17: 9, 18: 10 },
+  black_globe: { 15: 3, 16: 4, 17: 6, 18: 7 }
 };
 
 // Screen specs by hull code


### PR DESCRIPTION
## Summary
Screen quantity caps (Nuclear Damper, Meson Screen, Black Globe) previously topped out at TL-F and never increased, even though capital ships can now reach TL-G/H/J via the Longer Jumps and Robotics rules. Extends `SCREEN_TL_LIMITS` in `src/data/constants.ts` per spec:

| TL | Nuclear Damper | Meson Screen | Black Globe |
|---|---|---|---|
| F (was already there) | 6 | 6 | 3 |
| G | 8 | 8 | 4 |
| H | 10 | 9 | 6 |
| J | 12 | 10 | 7 |

Per-unit mass/cost is unchanged — that's driven by hull size (`SCREEN_SPECS_BY_HULL`), not TL. `DefensesPanel.tsx` already reads limits dynamically via `getMaxScreens()`/`getScreenSpecs()`, so no UI code changes were needed beyond the table itself.

## Test plan
- [x] `pnpm build` — succeeds
- [x] `pnpm lint` — clean
- [x] `pnpm test:run` — 212/212 passing (added `getMaxScreens` coverage in `constants.test.ts` for every TL tier of all three screen types)
- [ ] Manual UI check — no browser available in this environment; please verify the Defenses panel shows the new max counts at TL-G/H/J before merging

Claude-Session: https://claude.ai/code/session_01DXHBvdJ5mLZTWFRChrvkoU