### PR TITLE
Extend screen TL limits and add Robotics gunner reduction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,7 @@ Test files are co-located with source files using .test.ts/.test.tsx extension
 - `hasAntimatterPlant()` / `calculateAntimatterAdjustedManeuverFuel()`: an installed Antimatter Plant (in `fuel_systems`) cuts maneuver fuel to 1/10th
 - Staff calculation helpers (`calculateMedicalStaff`, `calculateVehicleServiceStaff`, `calculateDroneServiceStaff`)
 - `getScreenSpecs()`: defensive-screen (Nuclear Damper/Meson Screen/Black Globe) mass/cost, scaled by a 5x-per-tier tonnage bracket starting at 1,000,000 tons (see `getScreenTonnageTier()`) — not capital-ship hull codes, which topped out at 1,000,000 tons and didn't scale across the megastructure range
+- `getMaxScreens()` / `SCREEN_TL_LIMITS`: quantity cap per screen type, gated by TL (not tonnage). Nuclear Damper and Meson Screen scale TL-C through TL-J (1/1, 2/2, 4/4, 6/6, 8/8, 10/9, 12/10); Black Globe unlocks at TL-F and scales TL-F through TL-J (3, 4, 6, 7)
 
 **`src/types/ship.ts`**: TypeScript interfaces for all ship components
 - `ShipDesign`: Root interface containing all component arrays
@@ -316,6 +317,7 @@ Crew calculation in `calculateStaffRequirements()` (hoisted before JSX return in
   - Defensive screens: minimum 4, or `ceil(totalScreenTons / 100)` if total screen tonnage >400
   - Bay weapons: 2 gunners per bay weapon (per unit quantity)
   - No spinal weapon gunners — megastructures have no spinal mounts
+  - If the Robotics rule is enabled, the summed total above is divided (rounded up) by `getRoboticsGunnerDivisor(techLevel)` — one TL tier behind the Engineers reduction (starts at TL-G, not TL-F): TL-G=1/2, TL-H=1/3, TL-J=1/4
 - **Stewards**: 1 per 8 staterooms (rounded up)
 - **Medical**: Calculated by `calculateMedicalStaff()` based on medical facilities
 - **Service**: Vehicle service (`calculateVehicleServiceStaff`) + drone service (`calculateDroneServiceStaff`) from `constants.ts`
@@ -342,7 +344,7 @@ Use helper functions: `isTechLevelAtLeast()`, `getMaxPowerPlantByTechLevel()`, `
 - `'spacecraft_design_srd'`: always enabled, can't be disabled (display-only)
 - `'high_guard_capital_ships'`: always shown disabled (display-only, not applicable to megastructures)
 - `'antimatter'`: toggleable in the UI (gated to TL-H+ ships) but currently has no effect on any calculation
-- `'robotics'`: toggleable in the UI (gated to TL-F+ ships) and **does** affect calculations — `calculateEngineerCount()` (`src/utils/crewCalculations.ts`) divides each engine's crew requirement (rounded up) by `getRoboticsCrewDivisor(techLevel)` when enabled: TL-F=1/2, TL-G=1/4, TL-H=1/6, TL-J=1/8
+- `'robotics'`: toggleable in the UI (gated to TL-F+ ships) and **does** affect calculations — `calculateEngineerCount()` (`src/utils/crewCalculations.ts`) divides each engine's crew requirement (rounded up) by `getRoboticsCrewDivisor(techLevel)` when enabled: TL-F=1/2, TL-G=1/4, TL-H=1/6, TL-J=1/8. It also reduces total Gunners (in App.tsx's `calculateStaffRequirements()` directly, not a `crewCalculations.ts` helper) via `getRoboticsGunnerDivisor(techLevel)`, one TL tier later: TL-G=1/2, TL-H=1/3, TL-J=1/4
 
 If you add a new rule that should actually affect calculations, wire it through real game state (like the Antimatter Plant is) rather than `activeRules.has('rule_id')`, unless you're also adding the code that reads it (as `'robotics'` does).
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,8 @@ import {
   calculateControlCenterMass, calculateControlCenterCost,
   calculateArmorMass, calculateArmorCost,
   getMegastructureSections, PLANT_PER_SCOOP,
-  hasAntimatterPlant, calculateAntimatterAdjustedManeuverFuel
+  hasAntimatterPlant, calculateAntimatterAdjustedManeuverFuel,
+  getRoboticsGunnerDivisor
 } from './data/constants';
 import { databaseService } from './services/database';
 import { logger } from './utils/logger';
@@ -226,7 +227,13 @@ function App() {
     const bayWeaponGunners = bayWeapons.reduce((sum, weapon) => sum + (weapon.quantity * 2), 0);
 
     // No spinal weapon gunners — megastructures have no spinal mounts
-    const gunners = turretsAndBarbettesGunners + defenseTurretGunners + screenGunners + bayWeaponGunners;
+    const baseGunners = turretsAndBarbettesGunners + defenseTurretGunners + screenGunners + bayWeaponGunners;
+    // Robotics also automates gunnery support, one tier behind the
+    // engineering reduction above (starts at TL-G, not TL-F).
+    const gunnerDivisor = activeRules.has('robotics')
+      ? getRoboticsGunnerDivisor(shipDesign.ship.tech_level)
+      : 1;
+    const gunners = Math.ceil(baseGunners / gunnerDivisor);
 
     const vehicleService = calculateVehicleServiceStaff(shipDesign.vehicles);
     const droneService = calculateDroneServiceStaff(shipDesign.drones);

--- a/src/data/constants.test.ts
+++ b/src/data/constants.test.ts
@@ -7,12 +7,14 @@ import {
   getAvailableEngines,
   getMaxPowerPlantByTechLevel,
   getRoboticsCrewDivisor,
+  getRoboticsGunnerDivisor,
   hasAntimatterPlant,
   calculateAntimatterAdjustedManeuverFuel,
   getWeaponMountLimit,
   convertTechLevelToNumber,
   getAvailableVehicles,
   getScreenSpecs,
+  getMaxScreens,
 } from './constants';
 
 describe('Tech Level Functions', () => {
@@ -171,6 +173,55 @@ describe('getRoboticsCrewDivisor', () => {
     expect(getRoboticsCrewDivisor('G')).toBe(4);
     expect(getRoboticsCrewDivisor('H')).toBe(6);
     expect(getRoboticsCrewDivisor('J')).toBe(8);
+  });
+});
+
+describe('getRoboticsGunnerDivisor', () => {
+  it('applies no reduction below TL-G (including TL-F)', () => {
+    expect(getRoboticsGunnerDivisor('A')).toBe(1);
+    expect(getRoboticsGunnerDivisor('F')).toBe(1);
+  });
+
+  it('steps up with tech level: G=2, H=3, J=4', () => {
+    expect(getRoboticsGunnerDivisor('G')).toBe(2);
+    expect(getRoboticsGunnerDivisor('H')).toBe(3);
+    expect(getRoboticsGunnerDivisor('J')).toBe(4);
+  });
+});
+
+describe('getMaxScreens', () => {
+  it('should return 0 below TL-C for nuclear dampers and meson screens', () => {
+    expect(getMaxScreens('nuclear_damper', 'B')).toBe(0);
+    expect(getMaxScreens('meson_screen', 'B')).toBe(0);
+  });
+
+  it('should scale nuclear dampers and meson screens from TL-C through TL-J', () => {
+    expect(getMaxScreens('nuclear_damper', 'C')).toBe(1);
+    expect(getMaxScreens('nuclear_damper', 'D')).toBe(2);
+    expect(getMaxScreens('nuclear_damper', 'E')).toBe(4);
+    expect(getMaxScreens('nuclear_damper', 'F')).toBe(6);
+    expect(getMaxScreens('nuclear_damper', 'G')).toBe(8);
+    expect(getMaxScreens('nuclear_damper', 'H')).toBe(10);
+    expect(getMaxScreens('nuclear_damper', 'J')).toBe(12);
+
+    expect(getMaxScreens('meson_screen', 'C')).toBe(1);
+    expect(getMaxScreens('meson_screen', 'D')).toBe(2);
+    expect(getMaxScreens('meson_screen', 'E')).toBe(4);
+    expect(getMaxScreens('meson_screen', 'F')).toBe(6);
+    expect(getMaxScreens('meson_screen', 'G')).toBe(8);
+    expect(getMaxScreens('meson_screen', 'H')).toBe(9);
+    expect(getMaxScreens('meson_screen', 'J')).toBe(10);
+  });
+
+  it('should return 0 for black globes below TL-F', () => {
+    expect(getMaxScreens('black_globe', 'E')).toBe(0);
+  });
+
+  it('should scale black globes from TL-F through TL-J', () => {
+    expect(getMaxScreens('black_globe', 'F')).toBe(3);
+    expect(getMaxScreens('black_globe', 'G')).toBe(4);
+    expect(getMaxScreens('black_globe', 'H')).toBe(6);
+    expect(getMaxScreens('black_globe', 'J')).toBe(7);
   });
 });
 

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -62,6 +62,17 @@ export function getRoboticsCrewDivisor(techLevel: string): number {
   return 1;
 }
 
+// Robotics also automates gunnery support, one tier behind the engineering
+// reduction above (starts at TL-G, not TL-F): divisor to apply (rounded up)
+// to the ship's total gunner requirement. TL-G=1/2, TL-H=1/3, TL-J=1/4.
+// Below TL-G, no reduction (1).
+export function getRoboticsGunnerDivisor(techLevel: string): number {
+  if (isTechLevelAtLeast(techLevel, 'J')) return 4;
+  if (isTechLevelAtLeast(techLevel, 'H')) return 3;
+  if (isTechLevelAtLeast(techLevel, 'G')) return 2;
+  return 1;
+}
+
 // Engine performance percentages as a function of ship displacement.
 // Levels 1-6 are from the Traveller SRD. Megastructures have no jump drive,
 // so power plant levels 7-12 extend the same +1.0%/step progression from
@@ -333,11 +344,11 @@ export const DEFENSE_TYPES = [
   { name: 'Dual Point Defense Laser Turret', type: 'dual_point_defense_laser_turret', mass: 1, cost: 1.5 }
 ];
 
-// Screen types with TL-based quantity limits
+// Screen types with TL-based quantity limits. TL 16/17/18 = G/H/J.
 export const SCREEN_TL_LIMITS = {
-  nuclear_damper: { 12: 1, 13: 2, 14: 4, 15: 6 },
-  meson_screen: { 12: 1, 13: 2, 14: 4, 15: 6 },
-  black_globe: { 15: 3 }
+  nuclear_damper: { 12: 1, 13: 2, 14: 4, 15: 6, 16: 8, 17: 10, 18: 12 },
+  meson_screen: { 12: 1, 13: 2, 14: 4, 15: 6, 16: 8, 17: 9, 18: 10 },
+  black_globe: { 15: 3, 16: 4, 17: 6, 18: 7 }
 };
 
 // Screen specs by hull code


### PR DESCRIPTION
## Summary
Ports two changes from the same review just done on the `capital` branch:

- **Screen TL limits**: Nuclear Damper, Meson Screen, and Black Globe quantity caps previously topped out at TL-F and never increased, even though megastructures can reach TL-G/H/J. Extended `SCREEN_TL_LIMITS`:
  | TL | Nuclear Damper | Meson Screen | Black Globe |
  |---|---|---|---|
  | F (already there) | 6 | 6 | 3 |
  | G | 8 | 8 | 4 |
  | H | 10 | 9 | 6 |
  | J | 12 | 10 | 7 |

  Per-unit mass/cost is unchanged (still scales with tonnage tier via `getScreenSpecs()`, not TL). `DefensesPanel.tsx` already reads the max dynamically via `getMaxScreens()`, so no UI changes needed.

- **Robotics gunner reduction**: Robotics already reduces per-engine Engineer crew (`getRoboticsCrewDivisor`). Added a second factor, one TL tier later, that reduces the ship's total Gunner requirement: `getRoboticsGunnerDivisor()` — TL-G=1/2, TL-H=1/3, TL-J=1/4 (no reduction at TL-F). Applied directly in App.tsx's `calculateStaffRequirements()` and rounded up, same pattern as the existing engineer reduction.

## Test plan
- [x] `pnpm build` — succeeds
- [x] `pnpm lint` — clean
- [x] `pnpm test:run` — 221/221 passing (added `getRoboticsGunnerDivisor` and `getMaxScreens` coverage in `constants.test.ts`)
- [ ] Manual UI check — no browser available in this environment; please verify the Defenses panel shows the new max counts and the Staff panel shows reduced Gunners with Robotics enabled at TL-G+ before merging

Claude-Session: https://claude.ai/code/session_01DXHBvdJ5mLZTWFRChrvkoU