### PR TITLE
Give megastructure its own IndexedDB database, fixing save failures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ aid/
 │   ├── data/                   # Game data and constants
 │   │   └── constants.ts        # Tech levels, engines, weapons, megastructure formulas, etc.
 │   ├── services/                # Business logic
-│   │   ├── database.ts         # IndexedDB wrapper (store `mega_ships`, see Database Persistence below)
+│   │   ├── database.ts         # IndexedDB wrapper (own `MegastructureDesignerDB` database, store `mega_ships` — see Database Persistence below)
 │   │   └── initialDataService.ts # Initial data loader
 │   ├── types/                  # TypeScript definitions
 │   │   └── ship.ts             # Ship interfaces
@@ -114,7 +114,7 @@ Test files are co-located with source files using .test.ts/.test.tsx extension
 - **Bundler Config**: `vite.config.js` - entry point is `index.html` → `src/main.tsx`
 - **Dev Server**: Vite defaults (dev 5173, preview 4173)
 - **Node Version**: >=24 (LTS; specified in package.json engines)
-- **Deployment**: Cloudflare Worker, path prefix `/MegaDesign` under `srd-tools.com` — same origin as the sibling `main` (`/ShipDesign`) and `capital` (`/CapitalShipDesign`) branch deployments. This is why the IndexedDB store name matters (see Database Persistence).
+- **Deployment**: Cloudflare Worker, path prefix `/MegaDesign` under `srd-tools.com` — same origin as the sibling `main` (`/ShipDesign`) and `capital` (`/CapitalShipDesign`) branch deployments. This is why each app uses its own IndexedDB **database name**, not just its own store (see Database Persistence).
 
 ## Architecture Overview
 
@@ -145,7 +145,7 @@ Test files are co-located with source files using .test.ts/.test.tsx extension
 4. **Database Service Pattern**: `src/services/database.ts` provides IndexedDB abstraction
    - Ships are stored with unique names (enforced by unique index)
    - Auto-initialization loads `public/initial-ships.json` on first run
-   - Handles version migrations (currently at version 3)
+   - Handles version migrations (currently at version 1, in its own `MegastructureDesignerDB` database — see Database Persistence)
    - `databaseService.initialize()` is called exactly once at App startup via a `useEffect([], [])` — do not call it again in save/load handlers or component renders
 
 5. **`updateShipDesign()` side effects**: App.tsx's central update function isn't a pure merge — it runs several derived-state cleanups whenever the relevant field actually changes value (not just whenever it's present in the update payload):
@@ -236,13 +236,14 @@ const calcFM = (t, p, w, a) => { ... };
 
 ### Database Persistence
 
-**IndexedDB Schema** (version 3):
-- **Database**: `StarshipDesignerDB` — shared name across the `main`/`capital`/`megastructure` branches, since all three deploy to the same origin (`srd-tools.com`)
-- **Object Store**: `mega_ships` — deliberately branch-specific (main uses `ship_ships`, capital uses `capital_ships`) to avoid same-origin IndexedDB collisions between the three deployed apps
+**IndexedDB Schema** (version 1):
+- **Database**: `MegastructureDesignerDB` — this app's own database, distinct from main's `StarshipDesignerDB` and capital's `CapitalDesignerDB`. All three deploy to the same origin (`srd-tools.com`) but each now owns a separate database name so their version numbers can evolve independently with zero coordination needed between branches.
+- **Object Store**: `mega_ships`
 - **Key Path**: `id` (auto-increment)
 - **Indexes**:
   - `name` (unique) on `ship.name` - enforces unique ship names
   - `createdAt` on `createdAt` - for sorting
+- **Why a dedicated database, not just a dedicated store**: `main`/`capital`/`megastructure` originally shared one database name (`StarshipDesignerDB`) at this origin, each with its own store but pinned to the *same* version number. IndexedDB only runs `onupgradeneeded` (which creates a missing store) when the requested version is higher than whatever's already in the browser for that database name — so whichever app a user opened first "claimed" that version and created only its own store, leaving the other two with a `db` handle silently missing their store (surfaced as `"'<store>' is not a known object store name"` on the first `transaction()` call, typically on save). Splitting into per-app database names removes the collision permanently. One consequence: any ships a user saved in the old shared `StarshipDesignerDB`'s `mega_ships` store before this change are orphaned (still present in the browser, just no longer visible from this app) — there's no migration path, since the affected population is largely the same users who were already hitting the save bug and had nothing to migrate.
 
 **Initial Data**: On first load, if the `mega_ships` store is empty, `SelectShipPanel` calls `initialDataService.loadInitialDataIfNeeded()`, which preloads ships from `public/initial-ships.json` (currently a single "Ring World Alpha" seed). If that fails too, `SelectShipPanel` falls back to an in-memory hardcoded copy of the same ship so the screen is never empty.
 
@@ -394,7 +395,7 @@ Production deploys as a Cloudflare Worker (`wrangler deploy`, see `wrangler.json
 
 ## Debugging Tips
 
-1. **Database Issues**: Check browser DevTools → Application → IndexedDB → StarshipDesignerDB → `mega_ships` object store
+1. **Database Issues**: Check browser DevTools → Application → IndexedDB → MegastructureDesignerDB → `mega_ships` object store
 2. **Mass Calculation Problems**: Add console.log in `calculateMass()` to trace component contributions
 3. **Panel Validation**: Check `isCurrentPanelValid()` and `canAdvance()` in App.tsx
 4. **Initial Data Loading**: Check `SelectShipPanel.tsx` and `initialDataService.ts` for DB initialization logic

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -10,9 +10,22 @@ export interface StoredShipDesign extends ShipDesign {
 
 class DatabaseService {
   private db: IDBDatabase | null = null;
-  private readonly dbName = 'StarshipDesignerDB';
+  // Own database, distinct from main's StarshipDesignerDB and capital's
+  // CapitalDesignerDB. All three previously shared one database name
+  // (StarshipDesignerDB) at the same origin (srd-tools.com), each with its
+  // own store but pinned to the same version number. IndexedDB only runs
+  // onupgradeneeded (which creates a missing store) when the requested
+  // version is HIGHER than what's already in the browser for that
+  // database name - so whichever of the three apps a user opened first
+  // "claimed" that version and created only its own store, leaving the
+  // other two with a db handle silently missing their store (surfaces as
+  // "'<store>' is not a known object store name" on the first
+  // transaction, typically on save). Giving each app its own database
+  // name removes the collision entirely; each can now version its own
+  // schema independently.
+  private readonly dbName = 'MegastructureDesignerDB';
   private readonly storeName = 'mega_ships';
-  private readonly version = 3;
+  private readonly version = 1;
 
   async initialize(): Promise<void> {
     if (this.db) {
@@ -36,16 +49,6 @@ class DatabaseService {
       // IMPORTANT: the versionchange transaction auto-commits once no requests
       // are pending, so all migration work must stay in synchronous code or
       // request callbacks — no async/await or foreign promises in here.
-      //
-      // The legacy 'ships' store (v1/v2) is shared with the main Starship
-      // Designer app at the same origin (srd-tools.com) and historically held
-      // both apps' ships commingled with no way to tell them apart by data
-      // alone. Megastructures now live in their own 'mega_ships' store so
-      // future records never collide, and a schema bump in either app never
-      // forces the other to open a database version it doesn't understand.
-      // We deliberately do NOT read from or delete the legacy 'ships' store
-      // here: this app cannot reliably tell which of those records are its
-      // own, and main is responsible for migrating its own data out of it.
       request.onupgradeneeded = (event) => {
         const db = (event.target as IDBOpenDBRequest).result;
         const oldVersion = event.oldVersion;


### PR DESCRIPTION
## Summary
Companion fix to the same bug fixed on `capital`: `IDBDatabase.transaction: '<store>' is not a known object store name` when saving.

**Root cause**: `main`, `capital`, and `megastructure` all shared one IndexedDB database name (`StarshipDesignerDB`) at the same origin (`srd-tools.com`), each with its own object store but pinned to the *same* version number. IndexedDB only runs `onupgradeneeded` (which creates a missing store) when the requested version is higher than what's already in the browser for that database name — so whichever of the three apps a user opened **first** claimed that version and created only its own store. Any sibling app opened afterward requested that same already-current version, `onupgradeneeded` never fired, and that sibling got a `db` handle silently missing its own store.

**Fix**: give `megastructure` its own database name, `MegastructureDesignerDB`, so it no longer shares a version counter with `main` or `capital`. Reset to version 1 (fresh database, no prior version history). `main` keeps `StarshipDesignerDB` as its own now-exclusive database; `capital` got `CapitalDesignerDB` in a companion PR.

**Known consequence (no migration provided)**: any ships previously saved in the old shared `StarshipDesignerDB`'s `mega_ships` store (for users who happened to open `megastructure` first, before hitting this bug) are orphaned — still present in the browser, just no longer visible from this app. The affected population is largely the same users who were already hitting the save failure and had nothing to migrate.

## Test plan
- [x] `pnpm build` — succeeds
- [x] `pnpm lint` — clean
- [x] `pnpm test:run` — 221/221 passing
- [ ] Manual check — no browser available in this environment; please verify Save/Load works cleanly on a fresh browser profile, and after previously using `main`/`capital` in the same browser, before merging

Claude-Session: https://claude.ai/code/session_01DXHBvdJ5mLZTWFRChrvkoU