### PR TITLE
Extend Robotics crew discount from Gunners to Service and Stewards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,10 +319,10 @@ Crew calculation in `calculateStaffRequirements()` (hoisted before JSX return in
   - Defensive screens: minimum 4, or `ceil(totalScreenTons / 100)` if total screen tonnage >400
   - Bay weapons: 2 gunners per bay weapon (per unit quantity)
   - No spinal weapon gunners — megastructures have no spinal mounts
-  - If the Robotics rule is enabled, the summed total above is divided (rounded up) by `getRoboticsGunnerDivisor(techLevel)` — one TL tier behind the Engineers reduction (starts at TL-G, not TL-F): TL-G=1/2, TL-H=1/3, TL-J=1/4
-- **Stewards**: 1 per 8 staterooms (rounded up)
+  - If the Robotics rule is enabled, the summed total above is divided (rounded up) by `getRoboticsSupportDivisor(techLevel)` — one TL tier behind the Engineers reduction (starts at TL-G, not TL-F): TL-G=1/2, TL-H=1/3, TL-J=1/4
+- **Stewards**: 1 per 8 staterooms (rounded up); same `getRoboticsSupportDivisor(techLevel)` reduction as Gunners when the Robotics rule is enabled
 - **Medical**: Calculated by `calculateMedicalStaff()` based on medical facilities
-- **Service**: Vehicle service (`calculateVehicleServiceStaff`) + drone service (`calculateDroneServiceStaff`) from `constants.ts`
+- **Service**: Vehicle service (`calculateVehicleServiceStaff`) + drone service (`calculateDroneServiceStaff`) from `constants.ts`; same `getRoboticsSupportDivisor(techLevel)` reduction as Gunners when the Robotics rule is enabled
 - **Custom Crew** (`shipDesign.custom_crew`, entered on the Custom panel — see Common Modifications): added directly onto the corresponding field above for the 9 shared positions (pilot/navigator/engineers/gunners/service/stewards/nurses/surgeons/techs). **Infantry/Armor/MP/Security** have no baseline formula anywhere else in the app, so their `StaffRequirements` values are exactly whatever's entered as custom crew
 
 There is no small-ship pilot/navigator-combining or no-stewards toggle on this branch (that convention only applied to exactly-100/200-ton starships on the `main` branch; megastructures start at 1,000,000 tons, so it never applied here and was removed as dead code).
@@ -346,7 +346,7 @@ Use helper functions: `isTechLevelAtLeast()`, `getMaxPowerPlantByTechLevel()`, `
 - `'spacecraft_design_srd'`: always enabled, can't be disabled (display-only)
 - `'high_guard_capital_ships'`: always shown disabled (display-only, not applicable to megastructures)
 - `'antimatter'`: toggleable in the UI (gated to TL-H+ ships) but currently has no effect on any calculation
-- `'robotics'`: toggleable in the UI (gated to TL-F+ ships) and **does** affect calculations — `calculateEngineerCount()` (`src/utils/crewCalculations.ts`) divides each engine's crew requirement (rounded up) by `getRoboticsCrewDivisor(techLevel)` when enabled: TL-F=1/2, TL-G=1/4, TL-H=1/6, TL-J=1/8. It also reduces total Gunners (in App.tsx's `calculateStaffRequirements()` directly, not a `crewCalculations.ts` helper) via `getRoboticsGunnerDivisor(techLevel)`, one TL tier later: TL-G=1/2, TL-H=1/3, TL-J=1/4
+- `'robotics'`: toggleable in the UI (gated to TL-F+ ships) and **does** affect calculations — `calculateEngineerCount()` (`src/utils/crewCalculations.ts`) divides each engine's crew requirement (rounded up) by `getRoboticsCrewDivisor(techLevel)` when enabled: TL-F=1/2, TL-G=1/4, TL-H=1/6, TL-J=1/8. It also reduces total Gunners, Service, and Stewards (in App.tsx's `calculateStaffRequirements()` directly, not a `crewCalculations.ts` helper) via `getRoboticsSupportDivisor(techLevel)`, one TL tier later: TL-G=1/2, TL-H=1/3, TL-J=1/4
 
 If you add a new rule that should actually affect calculations, wire it through real game state (like the Antimatter Plant is) rather than `activeRules.has('rule_id')`, unless you're also adding the code that reads it (as `'robotics'` does).
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import {
   calculateArmorMass, calculateArmorCost,
   getMegastructureSections, PLANT_PER_SCOOP,
   hasAntimatterPlant, calculateAntimatterAdjustedManeuverFuel,
-  getRoboticsGunnerDivisor, getMinPowerPlantForFuelEquipment
+  getRoboticsSupportDivisor, getMinPowerPlantForFuelEquipment
 } from './data/constants';
 import { databaseService } from './services/database';
 import { logger } from './utils/logger';
@@ -228,21 +228,24 @@ function App() {
 
     // No spinal weapon gunners — megastructures have no spinal mounts
     const baseGunners = turretsAndBarbettesGunners + defenseTurretGunners + screenGunners + bayWeaponGunners;
-    // Robotics also automates gunnery support, one tier behind the
-    // engineering reduction above (starts at TL-G, not TL-F).
-    const gunnerDivisor = activeRules.has('robotics')
-      ? getRoboticsGunnerDivisor(shipDesign.ship.tech_level)
+    // Robotics also automates gunnery, service (vehicle/drone maintenance),
+    // and steward support, one tier behind the engineering reduction above
+    // (starts at TL-G, not TL-F). Same divisor applied to all three.
+    const roboticsSupportDivisor = activeRules.has('robotics')
+      ? getRoboticsSupportDivisor(shipDesign.ship.tech_level)
       : 1;
-    const gunners = Math.ceil(baseGunners / gunnerDivisor);
+    const gunners = Math.ceil(baseGunners / roboticsSupportDivisor);
 
     const vehicleService = calculateVehicleServiceStaff(shipDesign.vehicles);
     const droneService = calculateDroneServiceStaff(shipDesign.drones);
-    const service = vehicleService + droneService;
+    const baseService = vehicleService + droneService;
+    const service = Math.ceil(baseService / roboticsSupportDivisor);
 
     const totalStaterooms = shipDesign.berths
       .filter(berth => berth.berth_type === 'staterooms' || berth.berth_type === 'luxury_staterooms')
       .reduce((sum, berth) => sum + berth.quantity, 0);
-    const stewards = Math.ceil(totalStaterooms / 8);
+    const baseStewards = Math.ceil(totalStaterooms / 8);
+    const stewards = Math.ceil(baseStewards / roboticsSupportDivisor);
 
     const medicalStaff = calculateMedicalStaff(shipDesign.facilities);
     const { nurses: baseNurses, surgeons: baseSurgeons, techs: baseTechs } = medicalStaff;

--- a/src/data/constants.test.ts
+++ b/src/data/constants.test.ts
@@ -7,7 +7,7 @@ import {
   getAvailableEngines,
   getMaxPowerPlantByTechLevel,
   getRoboticsCrewDivisor,
-  getRoboticsGunnerDivisor,
+  getRoboticsSupportDivisor,
   hasAntimatterPlant,
   calculateAntimatterAdjustedManeuverFuel,
   getWeaponMountLimit,
@@ -180,16 +180,16 @@ describe('getRoboticsCrewDivisor', () => {
   });
 });
 
-describe('getRoboticsGunnerDivisor', () => {
+describe('getRoboticsSupportDivisor', () => {
   it('applies no reduction below TL-G (including TL-F)', () => {
-    expect(getRoboticsGunnerDivisor('A')).toBe(1);
-    expect(getRoboticsGunnerDivisor('F')).toBe(1);
+    expect(getRoboticsSupportDivisor('A')).toBe(1);
+    expect(getRoboticsSupportDivisor('F')).toBe(1);
   });
 
   it('steps up with tech level: G=2, H=3, J=4', () => {
-    expect(getRoboticsGunnerDivisor('G')).toBe(2);
-    expect(getRoboticsGunnerDivisor('H')).toBe(3);
-    expect(getRoboticsGunnerDivisor('J')).toBe(4);
+    expect(getRoboticsSupportDivisor('G')).toBe(2);
+    expect(getRoboticsSupportDivisor('H')).toBe(3);
+    expect(getRoboticsSupportDivisor('J')).toBe(4);
   });
 });
 

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -62,11 +62,11 @@ export function getRoboticsCrewDivisor(techLevel: string): number {
   return 1;
 }
 
-// Robotics also automates gunnery support, one tier behind the engineering
-// reduction above (starts at TL-G, not TL-F): divisor to apply (rounded up)
-// to the ship's total gunner requirement. TL-G=1/2, TL-H=1/3, TL-J=1/4.
-// Below TL-G, no reduction (1).
-export function getRoboticsGunnerDivisor(techLevel: string): number {
+// Robotics also automates gunnery, service (vehicle/drone maintenance), and
+// steward support, one tier behind the engineering reduction above (starts
+// at TL-G, not TL-F): divisor to apply (rounded up) to each of those crew
+// totals. TL-G=1/2, TL-H=1/3, TL-J=1/4. Below TL-G, no reduction (1).
+export function getRoboticsSupportDivisor(techLevel: string): number {
   if (isTechLevelAtLeast(techLevel, 'J')) return 4;
   if (isTechLevelAtLeast(techLevel, 'H')) return 3;
   if (isTechLevelAtLeast(techLevel, 'G')) return 2;


### PR DESCRIPTION
## Summary
The Robotics rule already reduced total **Gunners** via a tiered divisor (TL-G=1/2, TL-H=1/3, TL-J=1/4 — one tier behind the Engineers reduction, which starts at TL-F). This applies that same divisor to **Service** (vehicle/drone maintenance staff) and **Stewards** (1 per 8 staterooms) as well, since robot workers automate that support too, not just gunnery.

- Renamed \`getRoboticsGunnerDivisor\` → \`getRoboticsSupportDivisor\` to reflect the broader scope (same TL-G/H/J tiers, unchanged values).
- Applied to the pre-\`customCrew\` base values for all three (\`baseGunners\`, \`baseService\`, \`baseStewards\`), each rounded up independently — matching the existing Gunners pattern. \`customCrew\` additions remain unaffected by the reduction, same as before.
- Updated all references in \`CLAUDE.md\` and the test file.

## Test plan
- [x] \`pnpm build\` — succeeds
- [x] \`pnpm lint\` — clean
- [x] \`pnpm test:run\` — 249/249 passing (renamed/kept the divisor's own unit tests in \`constants.test.ts\`)
- [ ] Manual UI check — no browser available in this environment; please verify the Staff panel shows reduced Service/Stewards counts with Robotics enabled at TL-G+ before merging

Claude-Session: https://claude.ai/code/session_01DXHBvdJ5mLZTWFRChrvkoU