### PR TITLE
Ignore babel core/preset-typescript major bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,15 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # @babel/preset-typescript 8.0.1 mis-parses generic call/instantiation
+      # expressions (new Set<string>(), jest.fn<T>(), useState<T>()), and
+      # @babel/core 8.0.1 breaks the still-7.x preset-typescript peer dep.
+      # See PRs #218/#229/#230/#231/#233. Re-enable once babel fixes this.
+      - dependency-name: "@babel/core"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@babel/preset-typescript"
+        update-types: ["version-update:semver-major"]
 
   # ── npm packages → capital ───────────────────────────────────────────────
   - package-ecosystem: npm
@@ -42,6 +51,12 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # See "npm packages → main" ignore block above for why.
+      - dependency-name: "@babel/core"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@babel/preset-typescript"
+        update-types: ["version-update:semver-major"]
 
  # ── npm packages → megastructure ───────────────────────────────────────────────
   - package-ecosystem: npm
@@ -63,6 +78,12 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # See "npm packages → main" ignore block above for why.
+      - dependency-name: "@babel/core"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@babel/preset-typescript"
+        update-types: ["version-update:semver-major"]
 
   # ── GitHub Actions → main ────────────────────────────────────────────────
   - package-ecosystem: github-actions


### PR DESCRIPTION
## Summary
- \`@babel/preset-typescript\` 8.0.1 mis-parses TS generic call/instantiation expressions (`new Set<string>()`, `jest.fn<T>()`, `useState<T>()`), breaking the Jest suite across all three deployed branches (main, capital, megastructure).
- \`@babel/core\` 8.0.1 independently breaks things too, since the still-7.x \`preset-typescript\` declares a peer dep on \`@babel/core ^7.0.0-0\` and refuses to run.
- Confirmed via the failing CI runs on #218, #229, #230, #231, #233 — all fail the same way.
- Adds an \`ignore\` rule for major-version bumps of both packages to each npm section of dependabot.yml, so Dependabot stops proposing this broken combo until babel patches the regression upstream.

## Test plan
- [x] Confirmed megastructure branch tests are green (251/251) with @babel/core and @babel/preset-typescript still on 7.29.x, alongside the already-merged @babel/preset-env 8.0.2 / @babel/preset-react 8.0.1 bumps.
- [x] No functional code changes — dependabot.yml only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8sxnYAiMn44Arz8z2E46z