### PR TITLE
Add Shuttle/Modular Cutter/Fighter vehicles and swappable cutter modules

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,8 @@ import {
   calculateArmorMass, calculateArmorCost,
   getMegastructureSections, PLANT_PER_SCOOP,
   hasAntimatterPlant, calculateAntimatterAdjustedManeuverFuel,
-  getRoboticsSupportDivisor, getMinPowerPlantForFuelEquipment
+  getRoboticsSupportDivisor, getMinPowerPlantForFuelEquipment,
+  getModularCutterCount, calculateModularCutterBayMass, calculateModularCutterModuleCost
 } from './data/constants';
 import { databaseService } from './services/database';
 import { logger } from './utils/logger';
@@ -113,6 +114,11 @@ function App() {
     used += sumMassWithQuantity(shipDesign.drones);
     used += sumMass(shipDesign.custom_items);
 
+    // Modular Cutter spare-module reload bays (see calculateModularCutterBayMass)
+    const modularCutterCount = getModularCutterCount(shipDesign.vehicles);
+    const spareModuleCount = (shipDesign.modular_cutter_modules || []).reduce((sum, m) => sum + m.quantity, 0);
+    used += calculateModularCutterBayMass(modularCutterCount, spareModuleCount);
+
     // Maneuver fuel only — no jump drives on megastructures. An installed
     // Antimatter Plant reduces this to 1/10th (see hasAntimatterPlant).
     const maneuverDrive = shipDesign.engines.find(e => e.engine_type === 'maneuver_drive');
@@ -162,6 +168,9 @@ function App() {
     total += sumCostWithQuantity(shipDesign.vehicles);
     total += sumCostWithQuantity(shipDesign.drones);
     total += sumCost(shipDesign.custom_items);
+
+    // Modular Cutter spare modules (the reload bay itself is structural, no MCr cost)
+    total += calculateModularCutterModuleCost(shipDesign.modular_cutter_modules || []);
 
     total += shipDesign.ship.missile_reloads;
     total += shipDesign.ship.sand_reloads * 0.1;
@@ -447,7 +456,8 @@ function App() {
     let cleanedShipDesign: ShipDesign = {
       ...loadedShipDesign,
       fuel_systems: loadedShipDesign.fuel_systems || [],
-      zone_sections: loadedShipDesign.zone_sections || []
+      zone_sections: loadedShipDesign.zone_sections || [],
+      modular_cutter_modules: loadedShipDesign.modular_cutter_modules || []
     };
 
     if (removedWeapons.length > 0) {
@@ -485,7 +495,8 @@ function App() {
           onLoadExistingShip={(loadedShipDesign) => setShipDesign({
             ...loadedShipDesign,
             fuel_systems: loadedShipDesign.fuel_systems || [],
-            zone_sections: loadedShipDesign.zone_sections || []
+            zone_sections: loadedShipDesign.zone_sections || [],
+            modular_cutter_modules: loadedShipDesign.modular_cutter_modules || []
           })}
         />;
       case 1:
@@ -537,7 +548,13 @@ function App() {
       case 6:
         return <CargoPanel cargo={shipDesign.cargo} remainingMass={mass.remaining} shipTonnage={shipDesign.ship.tonnage} onUpdate={(cargo) => updateShipDesign({ cargo })} />;
       case 7:
-        return <VehiclesPanel vehicles={shipDesign.vehicles} shipTechLevel={shipDesign.ship.tech_level} onUpdate={(vehicles) => updateShipDesign({ vehicles })} />;
+        return <VehiclesPanel
+          vehicles={shipDesign.vehicles}
+          shipTechLevel={shipDesign.ship.tech_level}
+          modularCutterModules={shipDesign.modular_cutter_modules || []}
+          onUpdate={(vehicles) => updateShipDesign({ vehicles })}
+          onModulesUpdate={(modular_cutter_modules) => updateShipDesign({ modular_cutter_modules })}
+        />;
       case 8:
         return <DronesPanel drones={shipDesign.drones} onUpdate={(drones) => updateShipDesign({ drones })} />;
       case 9:

--- a/src/components/MassSidebar.tsx
+++ b/src/components/MassSidebar.tsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 import type { MassCalculation, CostCalculation, ShipDesign } from '../types/ship';
 import {
   calculateControlCenterMass, calculateArmorMass, PLANT_PER_SCOOP,
-  hasAntimatterPlant, calculateAntimatterAdjustedManeuverFuel
+  hasAntimatterPlant, calculateAntimatterAdjustedManeuverFuel,
+  getModularCutterCount, calculateModularCutterBayMass
 } from '../data/constants';
 import { sumMass, sumMassWithQuantity, sumCargoTonnage } from '../utils/calculations';
 
@@ -32,7 +33,10 @@ const MassSidebar: React.FC<MassSidebarProps> = ({ mass, cost, shipDesign }) => 
   const defensesMass = sumMassWithQuantity(shipDesign.defenses);
   const facilitiesMass = sumMassWithQuantity(shipDesign.facilities);
   const cargoMass = sumCargoTonnage(shipDesign.cargo);
-  const vehiclesMass = sumMassWithQuantity(shipDesign.vehicles);
+  const modularCutterCount = getModularCutterCount(shipDesign.vehicles);
+  const spareModuleCount = (shipDesign.modular_cutter_modules || []).reduce((sum, m) => sum + m.quantity, 0);
+  const moduleBayMass = calculateModularCutterBayMass(modularCutterCount, spareModuleCount);
+  const vehiclesMass = sumMassWithQuantity(shipDesign.vehicles) + moduleBayMass;
   const dronesMass = sumMassWithQuantity(shipDesign.drones);
   const customItemsMass = sumMass(shipDesign.custom_items);
   const berthsMass = sumMassWithQuantity(shipDesign.berths);
@@ -139,10 +143,13 @@ const MassSidebar: React.FC<MassSidebarProps> = ({ mass, cost, shipDesign }) => 
       name: 'Vehicles',
       mass: vehiclesMass,
       alwaysVisible: false,
-      items: shipDesign.vehicles.filter(v => v.quantity > 0).map(vehicle => ({
-        name: `${vehicle.vehicle_type.replace(/_/g, ' ')} (${vehicle.quantity})`,
-        mass: vehicle.mass * vehicle.quantity
-      }))
+      items: [
+        ...shipDesign.vehicles.filter(v => v.quantity > 0).map(vehicle => ({
+          name: `${vehicle.vehicle_type.replace(/_/g, ' ')} (${vehicle.quantity})`,
+          mass: vehicle.mass * vehicle.quantity
+        })),
+        ...(moduleBayMass > 0 ? [{ name: `Module reload bay + spares (${spareModuleCount})`, mass: moduleBayMass }] : [])
+      ]
     },
     {
       name: 'Drones',

--- a/src/components/SelectShipPanel.test.tsx
+++ b/src/components/SelectShipPanel.test.tsx
@@ -138,6 +138,7 @@ describe('SelectShipPanel', () => {
       facilities: [],
       cargo: [],
       vehicles: [],
+      modular_cutter_modules: [],
       drones: [],
       custom_items: [],
       custom_crew: {

--- a/src/components/SelectShipPanel.tsx
+++ b/src/components/SelectShipPanel.tsx
@@ -49,6 +49,7 @@ function createDefaultShips() {
       ],
       cargo: [],
       vehicles: [],
+      modular_cutter_modules: [],
       drones: [],
       custom_items: [],
       custom_crew: createEmptyCustomCrew(),

--- a/src/components/ShipPanel.tsx
+++ b/src/components/ShipPanel.tsx
@@ -49,6 +49,7 @@ const ShipPanel: React.FC<ShipPanelProps> = ({ ship, onUpdate, onLoadExistingShi
             facilities: existingShip.facilities,
             cargo: existingShip.cargo,
             vehicles: existingShip.vehicles,
+            modular_cutter_modules: existingShip.modular_cutter_modules || [],
             drones: existingShip.drones,
             custom_items: existingShip.custom_items || [],
             custom_crew: existingShip.custom_crew || createEmptyCustomCrew(),

--- a/src/components/SummaryPanel.tsx
+++ b/src/components/SummaryPanel.tsx
@@ -2,11 +2,12 @@ import { useState } from 'react';
 import type { ShipDesign, MassCalculation, CostCalculation, StaffRequirements } from '../types/ship';
 import {
   COMMS_SENSORS_TYPES, DEFENSE_TYPES, FACILITY_TYPES, CARGO_TYPES,
-  VEHICLE_TYPES, DRONE_TYPES, BERTH_TYPES, ZONE_SECTION_TYPES,
+  VEHICLE_TYPES, DRONE_TYPES, BERTH_TYPES, ZONE_SECTION_TYPES, MODULE_TYPES,
   calculateControlCenterMass, calculateControlCenterCost,
   calculateArmorMass, calculateArmorCost,
   getMegastructureSections, PLANT_PER_SCOOP,
-  hasAntimatterPlant, calculateAntimatterAdjustedManeuverFuel
+  hasAntimatterPlant, calculateAntimatterAdjustedManeuverFuel,
+  getModularCutterCount, calculateModularCutterBayMass
 } from '../data/constants';
 import { databaseService } from '../services/database';
 import { escapeCsvField } from '../utils/csv';
@@ -52,6 +53,14 @@ const SummaryPanel: React.FC<SummaryPanelProps> = ({ shipDesign, mass, cost, sta
   const armorCost = calculateArmorCost(armorMass);
 
   const zoneSections = shipDesign.zone_sections || [];
+
+  const modularCutterModules = shipDesign.modular_cutter_modules || [];
+  const modularCutterCount = getModularCutterCount(shipDesign.vehicles);
+  const spareModuleCount = modularCutterModules.reduce((sum, m) => sum + m.quantity, 0);
+  const moduleBayMass = calculateModularCutterBayMass(modularCutterCount, spareModuleCount);
+  // The 30 tons/module is itemized per selected module below; the remainder
+  // is the reload-bay retrofit tonnage, which has no module type of its own.
+  const moduleBayOverheadMass = moduleBayMass - spareModuleCount * 30;
 
   const handleSaveDesign = async () => {
     if (!shipDesign.ship.name.trim()) {
@@ -202,6 +211,14 @@ const SummaryPanel: React.FC<SummaryPanelProps> = ({ shipDesign, mass, cost, sta
       const display = vehicle.quantity === 1 ? name : `${name} (x${vehicle.quantity})`;
       allRows.push({ category: index === 0 ? 'Vehicles' : '', item: display, mass: vehicle.mass * vehicle.quantity, cost: vehicle.cost * vehicle.quantity });
     });
+    modularCutterModules.filter(m => m.quantity > 0).forEach(module => {
+      const moduleType = MODULE_TYPES.find(mt => mt.type === module.module_type);
+      const display = module.quantity === 1 ? (moduleType?.name ?? module.module_type) : `${moduleType?.name ?? module.module_type} (x${module.quantity})`;
+      allRows.push({ category: '', item: display, mass: module.quantity * 30, cost: (moduleType?.cost ?? 0) * module.quantity });
+    });
+    if (moduleBayOverheadMass > 0) {
+      allRows.push({ category: '', item: 'Modular Cutter Reload Bay', mass: moduleBayOverheadMass, cost: 0 });
+    }
 
     // Drones
     shipDesign.drones.filter(d => d.quantity > 0).forEach((drone, index) => {
@@ -394,6 +411,19 @@ const SummaryPanel: React.FC<SummaryPanelProps> = ({ shipDesign, mass, cost, sta
               const display = vehicle.quantity === 1 ? name : `${name} (x${vehicle.quantity})`;
               return <tr key={`vehicle_${vehicle.vehicle_type}`}><td>{index === 0 ? 'Vehicles' : ''}</td><td>{display}</td><td>{(vehicle.mass * vehicle.quantity).toFixed(1)} tons</td><td>{(vehicle.cost * vehicle.quantity).toFixed(2)} MCr</td></tr>;
             })}
+            {modularCutterModules.filter(m => m.quantity > 0).map(module => {
+              const moduleType = MODULE_TYPES.find(mt => mt.type === module.module_type);
+              const display = module.quantity === 1 ? (moduleType?.name ?? module.module_type) : `${moduleType?.name ?? module.module_type} (x${module.quantity})`;
+              return <tr key={`module_${module.module_type}`}><td></td><td>{display}</td><td>{(module.quantity * 30).toFixed(1)} tons</td><td>{((moduleType?.cost ?? 0) * module.quantity).toFixed(2)} MCr</td></tr>;
+            })}
+            {moduleBayOverheadMass > 0 && (
+              <tr key="module_bay_overhead">
+                <td></td>
+                <td>Modular Cutter Reload Bay</td>
+                <td>{moduleBayOverheadMass.toFixed(1)} tons</td>
+                <td>—</td>
+              </tr>
+            )}
 
             {/* Drones */}
             {shipDesign.drones.filter(d => d.quantity > 0).map((drone, index) => {

--- a/src/components/VehiclesPanel.tsx
+++ b/src/components/VehiclesPanel.tsx
@@ -1,16 +1,43 @@
 import React from 'react';
-import type { Vehicle } from '../types/ship';
-import { getAvailableVehicles, calculateVehicleServiceStaff } from '../data/constants';
+import type { Vehicle, ModularCutterModule } from '../types/ship';
+import {
+  getAvailableVehicles, calculateVehicleServiceStaff,
+  MODULE_TYPES, getModularCutterCount, calculateModularCutterBayMass, calculateModularCutterModuleCost
+} from '../data/constants';
 
 interface VehiclesPanelProps {
   vehicles: Vehicle[];
   shipTechLevel: string;
+  modularCutterModules: ModularCutterModule[];
   onUpdate: (vehicles: Vehicle[]) => void;
+  onModulesUpdate: (modules: ModularCutterModule[]) => void;
 }
 
-const VehiclesPanel: React.FC<VehiclesPanelProps> = ({ vehicles, shipTechLevel, onUpdate }) => {
+const VehiclesPanel: React.FC<VehiclesPanelProps> = ({ vehicles, shipTechLevel, modularCutterModules, onUpdate, onModulesUpdate }) => {
   const availableVehicles = getAvailableVehicles(shipTechLevel);
   const totalServiceStaff = calculateVehicleServiceStaff(vehicles);
+  const modularCutterCount = getModularCutterCount(vehicles);
+  const spareModuleCount = modularCutterModules.reduce((sum, m) => sum + m.quantity, 0);
+  const bayMass = calculateModularCutterBayMass(modularCutterCount, spareModuleCount);
+  const moduleCost = calculateModularCutterModuleCost(modularCutterModules);
+
+  const updateModuleQuantity = (moduleType: typeof MODULE_TYPES[0], quantity: number) => {
+    const validQuantity = Math.max(0, Math.floor(quantity));
+    const existingModule = modularCutterModules.find(m => m.module_type === moduleType.type);
+
+    if (validQuantity === 0) {
+      onModulesUpdate(modularCutterModules.filter(m => m.module_type !== moduleType.type));
+    } else if (existingModule) {
+      onModulesUpdate(modularCutterModules.map(m =>
+        m.module_type === moduleType.type ? { ...m, quantity: validQuantity } : m
+      ));
+    } else {
+      onModulesUpdate([...modularCutterModules, {
+        module_type: moduleType.type as ModularCutterModule['module_type'],
+        quantity: validQuantity
+      }]);
+    }
+  };
 
   const updateVehicleQuantity = (vehicleType: typeof availableVehicles[0], quantity: number) => {
     const validQuantity = Math.max(0, Math.floor(quantity));
@@ -123,6 +150,49 @@ const VehiclesPanel: React.FC<VehiclesPanelProps> = ({ vehicles, shipTechLevel, 
           </table>
         )}
       </div>
+
+      {modularCutterCount > 0 && (
+        <div className="module-bay-section">
+          <h3>Modular Cutter Modules</h3>
+          <p>
+            Each Modular Cutter's 50 tons already includes one installed module at no extra cost.
+            Carrying spare modules to swap in requires a reload bay retrofit across all {modularCutterCount} cutter{modularCutterCount === 1 ? '' : 's'}:
+            the first spare costs 60 tons/cutter (bay + module), every spare after that is a flat +30 tons.
+          </p>
+          <p><strong>Spare Modules:</strong> {spareModuleCount} &nbsp; <strong>Reload Bay + Spares Mass:</strong> {bayMass.toFixed(1)} tons &nbsp; <strong>Spare Modules Cost:</strong> {moduleCost.toFixed(1)} MCr</p>
+
+          <div className="vehicles-grouped-layout">
+            <div className="vehicle-group-row">
+              {MODULE_TYPES.map(moduleType => {
+                const currentModule = modularCutterModules.find(m => m.module_type === moduleType.type);
+                const quantity = currentModule?.quantity || 0;
+
+                return (
+                  <div key={moduleType.type} className="component-item">
+                    <div className="component-info">
+                      <h4>{moduleType.name}</h4>
+                      <p>{moduleType.mass} tons, {moduleType.cost} MCr</p>
+                      <p>{moduleType.description}</p>
+                    </div>
+                    <div className="quantity-control">
+                      <label>
+                        Quantity:
+                        <input
+                          type="number"
+                          min="0"
+                          value={quantity}
+                          onChange={(e) => updateModuleQuantity(moduleType, parseInt(e.target.value) || 0)}
+                          style={{ width: '60px', marginLeft: '0.5rem' }}
+                        />
+                      </label>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      )}
 
       <div className="vehicle-attribution">
         <p>

--- a/src/data/constants.test.ts
+++ b/src/data/constants.test.ts
@@ -18,6 +18,10 @@ import {
   getMinPowerPlantForFuelEquipment,
   formatPowerPlantCode,
   FRACTIONAL_POWER_PLANT_LEVELS,
+  getModularCutterCount,
+  calculateModularCutterBayMass,
+  calculateModularCutterModuleCost,
+  MODULE_TYPES,
 } from './constants';
 
 describe('Tech Level Functions', () => {
@@ -444,6 +448,58 @@ describe('getAvailableVehicles', () => {
     vehicles.forEach(v => {
       expect(v.techLevel).toBeLessThanOrEqual(shipTLNum);
     });
+  });
+});
+
+describe('getModularCutterCount', () => {
+  it('sums quantity across modular cutter entries', () => {
+    expect(getModularCutterCount([
+      { vehicle_type: 'modular_cutter', quantity: 3 },
+      { vehicle_type: 'shuttle', quantity: 5 }
+    ])).toBe(3);
+  });
+
+  it('returns 0 when no modular cutters are present', () => {
+    expect(getModularCutterCount([{ vehicle_type: 'shuttle', quantity: 2 }])).toBe(0);
+  });
+});
+
+describe('calculateModularCutterBayMass', () => {
+  it('is 0 with no spare modules', () => {
+    expect(calculateModularCutterBayMass(1, 0)).toBe(0);
+    expect(calculateModularCutterBayMass(3, 0)).toBe(0);
+  });
+
+  it('is 0 with no cutters even if spares are requested', () => {
+    expect(calculateModularCutterBayMass(0, 2)).toBe(0);
+  });
+
+  it('matches the single-cutter progression: 60, 90, 120 tons for 1, 2, 3 spares', () => {
+    expect(calculateModularCutterBayMass(1, 1)).toBe(60);
+    expect(calculateModularCutterBayMass(1, 2)).toBe(90);
+    expect(calculateModularCutterBayMass(1, 3)).toBe(120);
+  });
+
+  it('retrofits every cutter at once for the first spare, then +30 tons/spare after', () => {
+    expect(calculateModularCutterBayMass(2, 1)).toBe(120);
+    expect(calculateModularCutterBayMass(2, 2)).toBe(150);
+    expect(calculateModularCutterBayMass(3, 1)).toBe(180);
+  });
+});
+
+describe('calculateModularCutterModuleCost', () => {
+  it('sums quantity × per-type cost, ignoring the reload bay (structural, no MCr cost)', () => {
+    const cost = calculateModularCutterModuleCost([
+      { module_type: 'sensor_module', quantity: 2 },
+      { module_type: 'weapons_module', quantity: 1 }
+    ]);
+    const sensorCost = MODULE_TYPES.find(m => m.type === 'sensor_module')!.cost;
+    const weaponsCost = MODULE_TYPES.find(m => m.type === 'weapons_module')!.cost;
+    expect(cost).toBe(sensorCost * 2 + weaponsCost);
+  });
+
+  it('returns 0 for an empty list', () => {
+    expect(calculateModularCutterModuleCost([])).toBe(0);
   });
 });
 

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -536,8 +536,50 @@ export const VEHICLE_TYPES = [
   { name: 'Awesome AWS-8Q 80 ton Walker', type: 'awesome_walker', mass: 80, cost: 22, techLevel: 10, serviceStaff: 4 },
   { name: 'Socrates Field Car (Variant)', type: 'socrates_field_car_variant', mass: 5, cost: 0.168, techLevel: 9, serviceStaff: 1 },
   { name: 'Armored Fighting Vehicle', type: 'armored_fighting_vehicle', mass: 10, cost: 0.198, techLevel: 12, serviceStaff: 1 },
-  { name: 'Fury Helicopter Gunship (Refit)', type: 'fury_helicopter_gunship', mass: 8, cost: 1.2, techLevel: 8, serviceStaff: 1 }
+  { name: 'Fury Helicopter Gunship (Refit)', type: 'fury_helicopter_gunship', mass: 8, cost: 1.2, techLevel: 8, serviceStaff: 1 },
+  { name: 'Shuttle', type: 'shuttle', mass: 90, cost: 12, techLevel: 9, serviceStaff: 2 },
+  { name: 'Modular Cutter', type: 'modular_cutter', mass: 50, cost: 14, techLevel: 9, serviceStaff: 2 },
+  { name: 'Light Fighter', type: 'light_fighter', mass: 30, cost: 36, techLevel: 9, serviceStaff: 1 },
+  { name: 'Medium Fighter', type: 'medium_fighter', mass: 60, cost: 80, techLevel: 10, serviceStaff: 2 },
+  { name: 'Heavy Fighter', type: 'heavy_fighter', mass: 90, cost: 124, techLevel: 12, serviceStaff: 3 }
 ];
+
+// Swappable modules for the Modular Cutter — see ModularCutterModule in
+// types/ship.ts and calculateModularCutterBayMass() below for the tonnage
+// mechanic that governs how many of these a design can actually carry.
+export const MODULE_TYPES = [
+  { name: 'Sensor Module', type: 'sensor_module', mass: 30, cost: 40, description: 'Optical, radio/magnetic, and mass sensors.' },
+  { name: 'Fuel Module', type: 'fuel_module', mass: 30, cost: 3, description: '29.5 tons of fuel in a .5 ton bladder.' },
+  { name: 'Residence Module', type: 'residence_module', mass: 30, cost: 30, description: 'Reconfigurable up to 7 cabins, 3 smaller homes, or 2 large homes.' },
+  { name: 'Weapons Module', type: 'weapons_module', mass: 30, cost: 60, description: 'A selection of turrets (any laser, up to triple) and antipersonnel weapons with local power.' },
+  { name: 'Stealth Module', type: 'stealth_module', mass: 30, cost: 120, description: 'Advanced passive and active electromagnetic sensors, jammers, chaff, flares, and weasels (small mobile jammers with chaff and flares).' },
+  { name: 'Mining Module', type: 'mining_module', mass: 30, cost: 45, description: 'A mining laser and bulk processing machinery for asteroid mining and purification.' }
+];
+
+export function getModularCutterCount(vehicles: { vehicle_type: string; quantity: number }[]): number {
+  return vehicles
+    .filter(v => v.vehicle_type === 'modular_cutter')
+    .reduce((sum, v) => sum + v.quantity, 0);
+}
+
+// Each Modular Cutter's 50-ton hull already includes its one installed
+// module at no extra tonnage. Carrying any spares beyond that requires a
+// reload bay retrofit on every cutter at once (30 tons bay + 30 tons for
+// the first spare, per cutter = 60 tons/cutter); every spare beyond that
+// first one is a flat +30 tons with no further bay cost.
+export function calculateModularCutterBayMass(cutterCount: number, spareModuleCount: number): number {
+  if (cutterCount <= 0 || spareModuleCount <= 0) {
+    return 0;
+  }
+  return 60 * cutterCount + 30 * (spareModuleCount - 1);
+}
+
+export function calculateModularCutterModuleCost(modules: { module_type: string; quantity: number }[]): number {
+  return modules.reduce((sum, m) => {
+    const moduleType = MODULE_TYPES.find(mt => mt.type === m.module_type);
+    return sum + (moduleType ? moduleType.cost * m.quantity : 0);
+  }, 0);
+}
 
 export const DRONE_TYPES = [
   { name: 'War', type: 'war', mass: 10, cost: 2 },

--- a/src/types/ship.ts
+++ b/src/types/ship.ts
@@ -73,10 +73,20 @@ export interface Cargo {
 
 export interface Vehicle {
   id?: number;
-  vehicle_type: 'honey_badger_off_roader' | 'atv_tracked' | 'atv_wheeled' | 'air_raft_truck' | 'open_top_air_raft' | 'fire_scorpion_walker' | 'socrates_field_car' | 'ufo_floating_home' | 'sealed_air_raft_4t' | 'iderati_afv' | 'aat_infantry_support' | 'sealed_air_raft_3t' | 'pug_armored_car' | 'exploration_gbike' | 'awesome_walker' | 'socrates_field_car_variant' | 'armored_fighting_vehicle' | 'fury_helicopter_gunship';
+  vehicle_type: 'honey_badger_off_roader' | 'atv_tracked' | 'atv_wheeled' | 'air_raft_truck' | 'open_top_air_raft' | 'fire_scorpion_walker' | 'socrates_field_car' | 'ufo_floating_home' | 'sealed_air_raft_4t' | 'iderati_afv' | 'aat_infantry_support' | 'sealed_air_raft_3t' | 'pug_armored_car' | 'exploration_gbike' | 'awesome_walker' | 'socrates_field_car_variant' | 'armored_fighting_vehicle' | 'fury_helicopter_gunship' | 'shuttle' | 'modular_cutter' | 'light_fighter' | 'medium_fighter' | 'heavy_fighter';
   quantity: number;
   mass: number;
   cost: number;
+}
+
+// Swappable 30-ton modules for the Modular Cutter. Tracked as a flat count
+// per type across every Modular Cutter on the design (not per individual
+// cutter) — see calculateModularCutterBayMass() in constants.ts for why the
+// extra bay tonnage can't be attributed to a single module entry.
+export interface ModularCutterModule {
+  id?: number;
+  module_type: 'sensor_module' | 'fuel_module' | 'residence_module' | 'weapons_module' | 'stealth_module' | 'mining_module';
+  quantity: number;
 }
 
 export interface Drone {
@@ -157,6 +167,7 @@ export interface ShipDesign {
   facilities: Facility[];
   cargo: Cargo[];
   vehicles: Vehicle[];
+  modular_cutter_modules: ModularCutterModule[];
   drones: Drone[];
   custom_items: CustomItem[];
   custom_crew: CustomCrew;

--- a/src/utils/printContent.test.ts
+++ b/src/utils/printContent.test.ts
@@ -37,6 +37,7 @@ const baseShip: ShipDesign = {
   facilities: [],
   cargo: [],
   vehicles: [],
+  modular_cutter_modules: [],
   drones: [],
   custom_items: [],
   custom_crew: {

--- a/src/utils/printContent.ts
+++ b/src/utils/printContent.ts
@@ -1,11 +1,12 @@
 import type { ShipDesign, MassCalculation, CostCalculation, StaffRequirements } from '../types/ship';
 import {
   COMMS_SENSORS_TYPES, DEFENSE_TYPES, FACILITY_TYPES, CARGO_TYPES,
-  VEHICLE_TYPES, DRONE_TYPES, BERTH_TYPES, ZONE_SECTION_TYPES,
+  VEHICLE_TYPES, DRONE_TYPES, BERTH_TYPES, ZONE_SECTION_TYPES, MODULE_TYPES,
   calculateControlCenterMass, calculateControlCenterCost,
   calculateArmorMass, calculateArmorCost,
   getMegastructureSections, PLANT_PER_SCOOP,
-  hasAntimatterPlant, calculateAntimatterAdjustedManeuverFuel
+  hasAntimatterPlant, calculateAntimatterAdjustedManeuverFuel,
+  getModularCutterCount, calculateModularCutterBayMass
 } from '../data/constants';
 
 function escapeHtml(str: string): string {
@@ -145,6 +146,22 @@ export function generateShipPrintContent(
     const display = vehicle.quantity === 1 ? name : `${name} (x${vehicle.quantity})`;
     addRow(index === 0 ? 'Vehicles' : '', display, vehicle.mass * vehicle.quantity, vehicle.cost * vehicle.quantity);
   });
+
+  // Modular Cutter spare modules + reload bay
+  const modularCutterModules = shipDesign.modular_cutter_modules || [];
+  const modularCutterCount = getModularCutterCount(shipDesign.vehicles);
+  const spareModuleCount = modularCutterModules.reduce((sum, m) => sum + m.quantity, 0);
+  const moduleBayMass = calculateModularCutterBayMass(modularCutterCount, spareModuleCount);
+  const moduleBayOverheadMass = moduleBayMass - spareModuleCount * 30;
+  modularCutterModules.filter(m => m.quantity > 0).forEach(module => {
+    const moduleType = MODULE_TYPES.find(mt => mt.type === module.module_type);
+    const name = moduleType?.name || module.module_type;
+    const display = module.quantity === 1 ? name : `${name} (x${module.quantity})`;
+    addRow('', display, module.quantity * 30, (moduleType?.cost ?? 0) * module.quantity);
+  });
+  if (moduleBayOverheadMass > 0) {
+    addRow('', 'Modular Cutter Reload Bay', moduleBayOverheadMass, 0);
+  }
 
   // Drones
   shipDesign.drones.filter(d => d.quantity > 0).forEach((drone, index) => {

--- a/src/utils/shipDefaults.ts
+++ b/src/utils/shipDefaults.ts
@@ -35,6 +35,7 @@ export const createEmptyShipDesign = (shipInfo: Ship): ShipDesign => {
     facilities: [],
     cargo: [],
     vehicles: [],
+    modular_cutter_modules: [],
     drones: [],
     custom_items: [],
     custom_crew: createEmptyCustomCrew(),


### PR DESCRIPTION
## Summary
- Adds 5 new Vehicle types: Shuttle (90t, 12 MCr), Modular Cutter (50t, 14 MCr), Light Fighter (30t, 36 MCr), Medium Fighter (60t, 80 MCr), Heavy Fighter (90t, 124 MCr).
- Adds a Modular Cutter module bay system, shown on the Vehicles panel once a Modular Cutter is selected: 6 swappable 30-ton modules (Sensor 40 MCr, Fuel 3 MCr, Residence 30 MCr, Weapons 60 MCr, Stealth 120 MCr, Mining 45 MCr).
- Tonnage mechanic: each cutter's 50-ton hull already includes its one installed module at no extra cost. Carrying spares requires a reload-bay retrofit across every cutter at once (60 tons/cutter for the first spare, +30 tons per additional spare, no further bay cost after that).
- Wired into mass/cost calculation, MassSidebar, SummaryPanel (table + CSV), and print output.
- Backward-compatible: ships saved before this change (missing `modular_cutter_modules`) load fine via the existing `|| []` normalization pattern used for other optional fields.

Assumed defaults (not specified by requester, easy to tweak in `VEHICLE_TYPES`): tech level 9 for Shuttle/Modular Cutter/Light Fighter, TL 10 for Medium Fighter, TL 12 for Heavy Fighter; service staff 1-3 scaled roughly by mass.

## Test plan
- [x] `pnpm exec tsc -b` — passes
- [x] `pnpm lint` — passes
- [x] `pnpm test:run` — 259/259 passing, including new unit tests for `calculateModularCutterBayMass` / `calculateModularCutterModuleCost` covering the 60/90/120-ton progression and multi-cutter retrofit behavior
- [x] `pnpm build` — production build succeeds
- [ ] Manual browser check of the Vehicles panel UI (not done — Chrome extension wasn't connected in this session)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AfP6mdpd7rwyAAZsYjobER