### PR TITLE
Add Shuttle/Modular Cutter/Fighter vehicles and swappable cutter modules

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -340,6 +340,7 @@ describe('App', () => {
       facilities: [],
       cargo: [],
       vehicles: [],
+      modular_cutter_modules: [],
       drones: []
     };
     (databaseService.getAllShips as ReturnType<typeof jest.fn>).mockResolvedValueOnce([shipWithBadWeapon]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { Ship, ShipDesign, MassCalculation, CostCalculation, StaffRequirements } from './types/ship';
-import { calculateTotalFuelMass, calculateVehicleServiceStaff, calculateDroneServiceStaff, calculateMedicalStaff, convertTechLevelToNumber, getBridgeMassAndCost, getHullCost, getMaxJumpByTechLevel, VEHICLE_TYPES, WEAPON_TYPES } from './data/constants';
+import { calculateTotalFuelMass, calculateVehicleServiceStaff, calculateDroneServiceStaff, calculateMedicalStaff, convertTechLevelToNumber, getBridgeMassAndCost, getHullCost, getMaxJumpByTechLevel, VEHICLE_TYPES, WEAPON_TYPES, getModularCutterCount, calculateModularCutterBayMass, calculateModularCutterModuleCost } from './data/constants';
 import { databaseService } from './services/database';
 import { generateShipPrintContent } from './utils/printContent';
 import { logger } from './utils/logger';
@@ -40,6 +40,7 @@ const EMPTY_SHIP_DESIGN: ShipDesign = {
   facilities: [],
   cargo: [],
   vehicles: [],
+  modular_cutter_modules: [],
   drones: []
 };
 
@@ -113,6 +114,10 @@ function App() {
     used += shipDesign.facilities.reduce((sum, facility) => sum + (facility.mass * facility.quantity), 0);
     used += shipDesign.cargo.reduce((sum, cargo) => sum + cargo.tonnage, 0);
     used += shipDesign.vehicles.reduce((sum, vehicle) => sum + (vehicle.mass * vehicle.quantity), 0);
+    // Modular Cutter spare-module reload bays (see calculateModularCutterBayMass)
+    const modularCutterCount = getModularCutterCount(shipDesign.vehicles);
+    const spareModuleCount = (shipDesign.modular_cutter_modules || []).reduce((sum, m) => sum + m.quantity, 0);
+    used += calculateModularCutterBayMass(modularCutterCount, spareModuleCount);
     used += shipDesign.drones.reduce((sum, drone) => sum + (drone.mass * drone.quantity), 0);
     const jumpDrive = shipDesign.engines.find(e => e.engine_type === 'jump_drive');
     const maneuverDrive = shipDesign.engines.find(e => e.engine_type === 'maneuver_drive');
@@ -138,6 +143,8 @@ function App() {
     total += shipDesign.facilities.reduce((sum, facility) => sum + (facility.cost * facility.quantity), 0);
     total += shipDesign.cargo.reduce((sum, cargo) => sum + cargo.cost, 0);
     total += shipDesign.vehicles.reduce((sum, vehicle) => sum + (vehicle.cost * vehicle.quantity), 0);
+    // Modular Cutter spare modules (the reload bay itself is structural, no MCr cost)
+    total += calculateModularCutterModuleCost(shipDesign.modular_cutter_modules || []);
     total += shipDesign.drones.reduce((sum, drone) => sum + (drone.cost * drone.quantity), 0);
     total += shipDesign.ship.missile_reloads;
     total += shipDesign.ship.sand_reloads * 0.1;
@@ -467,7 +474,13 @@ function App() {
       case 6:
         return <CargoPanel cargo={shipDesign.cargo} remainingMass={mass.remaining} shipTonnage={shipDesign.ship.tonnage} onUpdate={(cargo) => updateShipDesign({ cargo })} />;
       case 7:
-        return <VehiclesPanel vehicles={shipDesign.vehicles} shipTechLevel={shipDesign.ship.tech_level} onUpdate={(vehicles) => updateShipDesign({ vehicles })} />;
+        return <VehiclesPanel
+          vehicles={shipDesign.vehicles}
+          shipTechLevel={shipDesign.ship.tech_level}
+          modularCutterModules={shipDesign.modular_cutter_modules || []}
+          onUpdate={(vehicles) => updateShipDesign({ vehicles })}
+          onModulesUpdate={(modular_cutter_modules) => updateShipDesign({ modular_cutter_modules })}
+        />;
       case 8:
         return <DronesPanel drones={shipDesign.drones} onUpdate={(drones) => updateShipDesign({ drones })} />;
       case 9:

--- a/src/components/MassSidebar.tsx
+++ b/src/components/MassSidebar.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import type { MassCalculation, CostCalculation, ShipDesign } from '../types/ship';
-import { calculateTotalFuelMass } from '../data/constants';
+import { calculateTotalFuelMass, getModularCutterCount, calculateModularCutterBayMass } from '../data/constants';
 
 interface MassSidebarProps {
   mass: MassCalculation;
@@ -29,7 +29,10 @@ const MassSidebar: React.FC<MassSidebarProps> = ({ mass, cost, shipDesign, activ
   const defensesMass = shipDesign.defenses.reduce((sum, defense) => sum + (defense.mass * defense.quantity), 0);
   const facilitiesMass = shipDesign.facilities.reduce((sum, facility) => sum + (facility.mass * facility.quantity), 0);
   const cargoMass = shipDesign.cargo.reduce((sum, cargo) => sum + cargo.tonnage, 0);
-  const vehiclesMass = shipDesign.vehicles.reduce((sum, vehicle) => sum + (vehicle.mass * vehicle.quantity), 0);
+  const modularCutterCount = getModularCutterCount(shipDesign.vehicles);
+  const spareModuleCount = (shipDesign.modular_cutter_modules || []).reduce((sum, m) => sum + m.quantity, 0);
+  const moduleBayMass = calculateModularCutterBayMass(modularCutterCount, spareModuleCount);
+  const vehiclesMass = shipDesign.vehicles.reduce((sum, vehicle) => sum + (vehicle.mass * vehicle.quantity), 0) + moduleBayMass;
   const dronesMass = shipDesign.drones.reduce((sum, drone) => sum + (drone.mass * drone.quantity), 0);
   const berthsMass = shipDesign.berths.reduce((sum, berth) => sum + (berth.mass * berth.quantity), 0);
 
@@ -105,10 +108,13 @@ const MassSidebar: React.FC<MassSidebarProps> = ({ mass, cost, shipDesign, activ
       name: 'Vehicles',
       mass: vehiclesMass,
       alwaysVisible: false,
-      items: shipDesign.vehicles.filter(v => v.quantity > 0).map(vehicle => ({
-        name: `${vehicle.vehicle_type.replace('_', ' ')} (${vehicle.quantity})`,
-        mass: vehicle.mass * vehicle.quantity
-      }))
+      items: [
+        ...shipDesign.vehicles.filter(v => v.quantity > 0).map(vehicle => ({
+          name: `${vehicle.vehicle_type.replace('_', ' ')} (${vehicle.quantity})`,
+          mass: vehicle.mass * vehicle.quantity
+        })),
+        ...(moduleBayMass > 0 ? [{ name: `Module reload bay + spares (${spareModuleCount})`, mass: moduleBayMass }] : [])
+      ]
     },
     {
       name: 'Drones',

--- a/src/components/RulesMenu.test.tsx
+++ b/src/components/RulesMenu.test.tsx
@@ -24,6 +24,7 @@ const createMockShipDesign = (techLevel: string): ShipDesign => ({
   facilities: [],
   cargo: [],
   vehicles: [],
+  modular_cutter_modules: [],
   drones: []
 });
 

--- a/src/components/SelectShipPanel.test.tsx
+++ b/src/components/SelectShipPanel.test.tsx
@@ -140,6 +140,7 @@ describe('SelectShipPanel', () => {
       facilities: [],
       cargo: [],
       vehicles: [],
+      modular_cutter_modules: [],
       drones: []
     };
     (databaseService.getAllShips as ReturnType<typeof jest.fn>)
@@ -257,7 +258,7 @@ describe('SelectShipPanel', () => {
         description: ''
       },
       engines: [], fittings: [], weapons: [], defenses: [], berths: [],
-      facilities: [], cargo: [], vehicles: [], drones: []
+      facilities: [], cargo: [], vehicles: [], modular_cutter_modules: [], drones: []
     };
     const oversizedShip = {
       ...smallShip,

--- a/src/components/SelectShipPanel.tsx
+++ b/src/components/SelectShipPanel.tsx
@@ -53,6 +53,7 @@ function createDefaultShips(): StoredShipDesign[] {
       { cargo_type: 'secure_storage_bay', tonnage: 1, cost: 0.7 }
     ],
     vehicles: [{ vehicle_type: 'air_raft_truck', quantity: 1, mass: 5, cost: 0.55 }],
+    modular_cutter_modules: [],
     drones: [],
     createdAt: new Date(),
     updatedAt: new Date()
@@ -91,6 +92,7 @@ function createDefaultShips(): StoredShipDesign[] {
       { cargo_type: 'spares', tonnage: 1, cost: 0.5 }
     ],
     vehicles: [],
+    modular_cutter_modules: [],
     drones: [],
     createdAt: new Date(),
     updatedAt: new Date()
@@ -139,6 +141,7 @@ function createDefaultShips(): StoredShipDesign[] {
       { cargo_type: 'secure_storage_bay', tonnage: 1, cost: 0.7 }
     ],
     vehicles: [{ vehicle_type: 'air_raft_truck', quantity: 1, mass: 5, cost: 0.55 }],
+    modular_cutter_modules: [],
     drones: [],
     createdAt: new Date(),
     updatedAt: new Date()

--- a/src/components/ShipPanel.test.tsx
+++ b/src/components/ShipPanel.test.tsx
@@ -38,6 +38,7 @@ const _createMockShipDesign = (ship: Ship): ShipDesign => ({
   facilities: [],
   cargo: [],
   vehicles: [],
+  modular_cutter_modules: [],
   drones: []
 });
 
@@ -146,6 +147,7 @@ describe('ShipPanel', () => {
       facilities: [],
       cargo: [],
       vehicles: [],
+      modular_cutter_modules: [],
       drones: []
     });
 

--- a/src/components/ShipPanel.tsx
+++ b/src/components/ShipPanel.tsx
@@ -48,6 +48,7 @@ const ShipPanel: React.FC<ShipPanelProps> = ({ ship, onUpdate, onLoadExistingShi
             facilities: existingShip.facilities,
             cargo: existingShip.cargo,
             vehicles: existingShip.vehicles,
+            modular_cutter_modules: existingShip.modular_cutter_modules || [],
             drones: existingShip.drones
           }
         });

--- a/src/components/SummaryPanel.tsx
+++ b/src/components/SummaryPanel.tsx
@@ -1,6 +1,10 @@
 import { useState } from 'react';
 import type { ShipDesign, MassCalculation, CostCalculation, StaffRequirements } from '../types/ship';
-import { COMMS_SENSORS_TYPES, DEFENSE_TYPES, FACILITY_TYPES, CARGO_TYPES, VEHICLE_TYPES, DRONE_TYPES, BERTH_TYPES, getHullCost } from '../data/constants';
+import {
+  COMMS_SENSORS_TYPES, DEFENSE_TYPES, FACILITY_TYPES, CARGO_TYPES,
+  VEHICLE_TYPES, DRONE_TYPES, BERTH_TYPES, MODULE_TYPES, getHullCost,
+  getModularCutterCount, calculateModularCutterBayMass
+} from '../data/constants';
 import { databaseService } from '../services/database';
 import { logger } from '../utils/logger';
 
@@ -23,6 +27,14 @@ const SummaryPanel: React.FC<SummaryPanelProps> = ({ shipDesign, mass, cost, sta
   const isSmallShip = shipDesign.ship.tonnage >= 100 && shipDesign.ship.tonnage <= 200;
   const applyCombine = combinePilotNavigator && isSmallShip;
   const applyNoStewards = noStewards && isSmallShip;
+
+  const modularCutterModules = shipDesign.modular_cutter_modules || [];
+  const modularCutterCount = getModularCutterCount(shipDesign.vehicles);
+  const spareModuleCount = modularCutterModules.reduce((sum, m) => sum + m.quantity, 0);
+  const moduleBayMass = calculateModularCutterBayMass(modularCutterCount, spareModuleCount);
+  // The 30 tons/module is itemized per selected module below; the remainder
+  // is the reload-bay retrofit tonnage, which has no module type of its own.
+  const moduleBayOverheadMass = moduleBayMass - spareModuleCount * 30;
 
   const handleSaveDesign = async () => {
     if (!shipDesign.ship.name.trim()) {
@@ -261,7 +273,16 @@ const SummaryPanel: React.FC<SummaryPanelProps> = ({ shipDesign, mass, cost, sta
         cost: vehicle.cost * vehicle.quantity
       });
     });
-    
+
+    modularCutterModules.filter(m => m.quantity > 0).forEach(module => {
+      const moduleType = MODULE_TYPES.find(mt => mt.type === module.module_type);
+      const display = module.quantity === 1 ? (moduleType?.name ?? module.module_type) : `${moduleType?.name ?? module.module_type} (x${module.quantity})`;
+      allRows.push({ category: '', item: display, mass: module.quantity * 30, cost: (moduleType?.cost ?? 0) * module.quantity });
+    });
+    if (moduleBayOverheadMass > 0) {
+      allRows.push({ category: '', item: 'Modular Cutter Reload Bay', mass: moduleBayOverheadMass, cost: 0 });
+    }
+
     // Drones
     const activeDrones = shipDesign.drones.filter(drone => drone.quantity > 0);
     activeDrones.forEach((drone, index) => {
@@ -613,10 +634,36 @@ const SummaryPanel: React.FC<SummaryPanelProps> = ({ shipDesign, mass, cost, sta
                   vehicleRowIndex++;
                 });
               }
-              
+
+              modularCutterModules.filter(m => m.quantity > 0).forEach(module => {
+                const moduleType = MODULE_TYPES.find(mt => mt.type === module.module_type);
+                const display = module.quantity === 1 ? (moduleType?.name ?? module.module_type) : `${moduleType?.name ?? module.module_type} (x${module.quantity})`;
+                rows.push(
+                  <tr key={`module_${module.module_type}`}>
+                    <td>{vehicleRowIndex === 0 ? 'Vehicles' : ''}</td>
+                    <td>{display}</td>
+                    <td>{(module.quantity * 30).toFixed(1)} tons</td>
+                    <td>{((moduleType?.cost ?? 0) * module.quantity).toFixed(2)} MCr</td>
+                  </tr>
+                );
+                vehicleRowIndex++;
+              });
+
+              if (moduleBayOverheadMass > 0) {
+                rows.push(
+                  <tr key="module_bay_overhead">
+                    <td>{vehicleRowIndex === 0 ? 'Vehicles' : ''}</td>
+                    <td>Modular Cutter Reload Bay</td>
+                    <td>{moduleBayOverheadMass.toFixed(1)} tons</td>
+                    <td>—</td>
+                  </tr>
+                );
+                vehicleRowIndex++;
+              }
+
               return rows;
             })()}
-            
+
             {/* Drones */}
             {(() => {
               const rows: React.ReactElement[] = [];

--- a/src/components/VehiclesPanel.test.tsx
+++ b/src/components/VehiclesPanel.test.tsx
@@ -2,12 +2,12 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import '@testing-library/jest-dom';
 import VehiclesPanel from './VehiclesPanel';
-import type { Vehicle } from '../types/ship';
+import type { Vehicle, ModularCutterModule } from '../types/ship';
 
 const noOp = jest.fn();
 
-const renderPanel = (vehicles: Vehicle[] = [], shipTechLevel = 'A') =>
-  render(<VehiclesPanel vehicles={vehicles} shipTechLevel={shipTechLevel} onUpdate={noOp} />);
+const renderPanel = (vehicles: Vehicle[] = [], shipTechLevel = 'A', modularCutterModules: ModularCutterModule[] = []) =>
+  render(<VehiclesPanel vehicles={vehicles} shipTechLevel={shipTechLevel} modularCutterModules={modularCutterModules} onUpdate={noOp} onModulesUpdate={noOp} />);
 
 describe('VehiclesPanel', () => {
   beforeEach(() => jest.clearAllMocks());
@@ -36,7 +36,7 @@ describe('VehiclesPanel', () => {
 
   it('+ button adds a vehicle', () => {
     const onUpdate = jest.fn();
-    render(<VehiclesPanel vehicles={[]} shipTechLevel="A" onUpdate={onUpdate} />);
+    render(<VehiclesPanel vehicles={[]} shipTechLevel="A" modularCutterModules={[]} onUpdate={onUpdate} onModulesUpdate={noOp} />);
     const plusButtons = screen.getAllByText('+');
     fireEvent.click(plusButtons[0]); // first available vehicle at TL A
     expect(onUpdate).toHaveBeenCalledWith(
@@ -47,7 +47,7 @@ describe('VehiclesPanel', () => {
   it('+ button increments existing vehicle quantity', () => {
     const onUpdate = jest.fn();
     const vehicles: Vehicle[] = [{ vehicle_type: 'open_top_air_raft', quantity: 1, mass: 4, cost: 0.045 }];
-    render(<VehiclesPanel vehicles={vehicles} shipTechLevel="A" onUpdate={onUpdate} />);
+    render(<VehiclesPanel vehicles={vehicles} shipTechLevel="A" modularCutterModules={[]} onUpdate={onUpdate} onModulesUpdate={noOp} />);
     const plusButtons = screen.getAllByText('+');
     // Find + for open_top_air_raft (which is first available at TL A)
     fireEvent.click(plusButtons[0]);
@@ -59,7 +59,7 @@ describe('VehiclesPanel', () => {
   it('- button decrements vehicle and removes at 0', () => {
     const onUpdate = jest.fn();
     const vehicles: Vehicle[] = [{ vehicle_type: 'open_top_air_raft', quantity: 1, mass: 4, cost: 0.045 }];
-    render(<VehiclesPanel vehicles={vehicles} shipTechLevel="A" onUpdate={onUpdate} />);
+    render(<VehiclesPanel vehicles={vehicles} shipTechLevel="A" modularCutterModules={[]} onUpdate={onUpdate} onModulesUpdate={noOp} />);
     const minusButtons = screen.getAllByText('-');
     const enabledMinus = minusButtons.find(btn => !btn.hasAttribute('disabled'));
     fireEvent.click(enabledMinus!);
@@ -76,7 +76,7 @@ describe('VehiclesPanel', () => {
   it('shows service staff count when vehicles with serviceStaff > 0 are present', () => {
     // Air/Raft Truck has serviceStaff: 1, available at TL C
     const vehicles: Vehicle[] = [{ vehicle_type: 'air_raft_truck', quantity: 1, mass: 5, cost: 0.55 }];
-    const { container } = render(<VehiclesPanel vehicles={vehicles} shipTechLevel="C" onUpdate={noOp} />);
+    const { container } = render(<VehiclesPanel vehicles={vehicles} shipTechLevel="C" modularCutterModules={[]} onUpdate={noOp} onModulesUpdate={noOp} />);
     // <p><strong>Total Service Staff Required:</strong> 1</p>
     expect(container.textContent).toMatch(/Total Service Staff Required:.*1/);
   });

--- a/src/components/VehiclesPanel.tsx
+++ b/src/components/VehiclesPanel.tsx
@@ -1,16 +1,48 @@
 import React from 'react';
-import type { Vehicle } from '../types/ship';
-import { getAvailableVehicles, calculateVehicleServiceStaff } from '../data/constants';
+import type { Vehicle, ModularCutterModule } from '../types/ship';
+import {
+  getAvailableVehicles, calculateVehicleServiceStaff,
+  MODULE_TYPES, getModularCutterCount, calculateModularCutterBayMass, calculateModularCutterModuleCost
+} from '../data/constants';
 
 interface VehiclesPanelProps {
   vehicles: Vehicle[];
   shipTechLevel: string;
+  modularCutterModules: ModularCutterModule[];
   onUpdate: (vehicles: Vehicle[]) => void;
+  onModulesUpdate: (modules: ModularCutterModule[]) => void;
 }
 
-const VehiclesPanel: React.FC<VehiclesPanelProps> = ({ vehicles, shipTechLevel, onUpdate }) => {
+const VehiclesPanel: React.FC<VehiclesPanelProps> = ({ vehicles, shipTechLevel, modularCutterModules, onUpdate, onModulesUpdate }) => {
   const availableVehicles = getAvailableVehicles(shipTechLevel);
   const totalServiceStaff = calculateVehicleServiceStaff(vehicles);
+  const modularCutterCount = getModularCutterCount(vehicles);
+  const spareModuleCount = modularCutterModules.reduce((sum, m) => sum + m.quantity, 0);
+  const moduleBayMass = calculateModularCutterBayMass(modularCutterCount, spareModuleCount);
+  const moduleCost = calculateModularCutterModuleCost(modularCutterModules);
+
+  const addModule = (moduleType: typeof MODULE_TYPES[0]) => {
+    const existingModule = modularCutterModules.find(m => m.module_type === moduleType.type);
+    if (existingModule) {
+      onModulesUpdate(modularCutterModules.map(m =>
+        m.module_type === moduleType.type ? { ...m, quantity: m.quantity + 1 } : m
+      ));
+    } else {
+      onModulesUpdate([...modularCutterModules, {
+        module_type: moduleType.type as ModularCutterModule['module_type'],
+        quantity: 1
+      }]);
+    }
+  };
+
+  const removeModule = (moduleType: string) => {
+    const newModules = modularCutterModules.map(m =>
+      m.module_type === moduleType
+        ? { ...m, quantity: Math.max(0, m.quantity - 1) }
+        : m
+    ).filter(m => m.quantity > 0);
+    onModulesUpdate(newModules);
+  };
 
   const addVehicle = (vehicleType: typeof availableVehicles[0]) => {
     const existingVehicle = vehicles.find(v => v.vehicle_type === vehicleType.type);
@@ -122,10 +154,87 @@ const VehiclesPanel: React.FC<VehiclesPanelProps> = ({ vehicles, shipTechLevel, 
         )}
       </div>
 
+      {modularCutterCount > 0 && (
+        <div className="module-bay-section">
+          <h3>Modular Cutter Modules</h3>
+          <p>
+            Each Modular Cutter's 50 tons already includes one installed module at no extra cost.
+            Carrying spare modules to swap in requires a reload bay retrofit across all {modularCutterCount} cutter{modularCutterCount === 1 ? '' : 's'}:
+            the first spare costs 60 tons/cutter (bay + module), every spare after that is a flat +30 tons.
+          </p>
+          <p><strong>Spare Modules:</strong> {spareModuleCount} &nbsp; <strong>Reload Bay + Spares Mass:</strong> {moduleBayMass.toFixed(1)} tons &nbsp; <strong>Spare Modules Cost:</strong> {moduleCost.toFixed(1)} MCr</p>
+
+          <div className="vehicles-grouped-layout">
+            <div className="vehicle-group-row">
+              {MODULE_TYPES.map(moduleType => {
+                const currentModule = modularCutterModules.find(m => m.module_type === moduleType.type);
+                const quantity = currentModule?.quantity || 0;
+
+                return (
+                  <div key={moduleType.type} className="component-item">
+                    <div className="component-info">
+                      <h4>{moduleType.name}</h4>
+                      <p>{moduleType.mass} tons, {moduleType.cost} MCr</p>
+                      <p>{moduleType.description}</p>
+                    </div>
+                    <div className="quantity-control">
+                      <button
+                        onClick={() => removeModule(moduleType.type)}
+                        disabled={quantity === 0}
+                      >
+                        -
+                      </button>
+                      <span>{quantity}</span>
+                      <button
+                        onClick={() => addModule(moduleType)}
+                      >
+                        +
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="vehicle-summary">
+            <h3>Module Summary</h3>
+            {modularCutterModules.length === 0 ? (
+              <p>No modules configured.</p>
+            ) : (
+              <table>
+                <thead>
+                  <tr>
+                    <th>Module Type</th>
+                    <th>Quantity</th>
+                    <th>Mass (t)</th>
+                    <th>Cost (MCr)</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {modularCutterModules.map(module => {
+                    const moduleType = MODULE_TYPES.find(mt => mt.type === module.module_type);
+
+                    return (
+                      <tr key={module.module_type}>
+                        <td>{moduleType?.name || module.module_type}</td>
+                        <td>{module.quantity}</td>
+                        <td>{(module.quantity * 30).toFixed(1)}</td>
+                        <td>{((moduleType?.cost ?? 0) * module.quantity).toFixed(3)}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            )}
+          </div>
+        </div>
+      )}
+
       <div className="vehicle-attribution">
         <p>
-          <a 
-            href="https://drive.google.com/drive/folders/1DKuxqeL2wTd8Hh9rsScdXkm2WdMubYps" 
+          <a
+            href="https://drive.google.com/drive/folders/1DKuxqeL2wTd8Hh9rsScdXkm2WdMubYps"
             target="_blank" 
             rel="noopener noreferrer"
           >

--- a/src/data/constants.test.ts
+++ b/src/data/constants.test.ts
@@ -15,6 +15,10 @@ import {
   getAvailableVehicles,
   HULL_SIZES,
   MAX_SHIP_TONNAGE,
+  getModularCutterCount,
+  calculateModularCutterBayMass,
+  calculateModularCutterModuleCost,
+  MODULE_TYPES,
 } from './constants';
 
 describe('MAX_SHIP_TONNAGE', () => {
@@ -499,5 +503,57 @@ describe('getAvailableVehicles', () => {
     const shipTL = convertTechLevelToNumber('B'); // 11
     const vehicles = getAvailableVehicles('B');
     expect(vehicles.every(v => v.techLevel <= shipTL)).toBe(true);
+  });
+});
+
+describe('getModularCutterCount', () => {
+  it('sums quantity across modular cutter entries', () => {
+    expect(getModularCutterCount([
+      { vehicle_type: 'modular_cutter', quantity: 3 },
+      { vehicle_type: 'shuttle', quantity: 5 }
+    ])).toBe(3);
+  });
+
+  it('returns 0 when no modular cutters are present', () => {
+    expect(getModularCutterCount([{ vehicle_type: 'shuttle', quantity: 2 }])).toBe(0);
+  });
+});
+
+describe('calculateModularCutterBayMass', () => {
+  it('is 0 with no spare modules', () => {
+    expect(calculateModularCutterBayMass(1, 0)).toBe(0);
+    expect(calculateModularCutterBayMass(3, 0)).toBe(0);
+  });
+
+  it('is 0 with no cutters even if spares are requested', () => {
+    expect(calculateModularCutterBayMass(0, 2)).toBe(0);
+  });
+
+  it('matches the single-cutter progression: 60, 90, 120 tons for 1, 2, 3 spares', () => {
+    expect(calculateModularCutterBayMass(1, 1)).toBe(60);
+    expect(calculateModularCutterBayMass(1, 2)).toBe(90);
+    expect(calculateModularCutterBayMass(1, 3)).toBe(120);
+  });
+
+  it('retrofits every cutter at once for the first spare, then +30 tons/spare after', () => {
+    expect(calculateModularCutterBayMass(2, 1)).toBe(120);
+    expect(calculateModularCutterBayMass(2, 2)).toBe(150);
+    expect(calculateModularCutterBayMass(3, 1)).toBe(180);
+  });
+});
+
+describe('calculateModularCutterModuleCost', () => {
+  it('sums quantity × per-type cost, ignoring the reload bay (structural, no MCr cost)', () => {
+    const cost = calculateModularCutterModuleCost([
+      { module_type: 'sensor_module', quantity: 2 },
+      { module_type: 'weapons_module', quantity: 1 }
+    ]);
+    const sensorCost = MODULE_TYPES.find(m => m.type === 'sensor_module')!.cost;
+    const weaponsCost = MODULE_TYPES.find(m => m.type === 'weapons_module')!.cost;
+    expect(cost).toBe(sensorCost * 2 + weaponsCost);
+  });
+
+  it('returns 0 for an empty list', () => {
+    expect(calculateModularCutterModuleCost([])).toBe(0);
   });
 });

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -583,8 +583,50 @@ export const VEHICLE_TYPES = [
   { name: 'Awesome AWS-8Q 80 ton Walker', type: 'awesome_walker', mass: 80, cost: 22, techLevel: 10, serviceStaff: 4 },
   { name: 'Socrates Field Car (Variant)', type: 'socrates_field_car_variant', mass: 5, cost: 0.168, techLevel: 9, serviceStaff: 1 },
   { name: 'Armored Fighting Vehicle', type: 'armored_fighting_vehicle', mass: 10, cost: 0.198, techLevel: 12, serviceStaff: 1 },
-  { name: 'Fury Helicopter Gunship (Refit)', type: 'fury_helicopter_gunship', mass: 8, cost: 1.2, techLevel: 8, serviceStaff: 1 }
+  { name: 'Fury Helicopter Gunship (Refit)', type: 'fury_helicopter_gunship', mass: 8, cost: 1.2, techLevel: 8, serviceStaff: 1 },
+  { name: 'Shuttle', type: 'shuttle', mass: 90, cost: 12, techLevel: 9, serviceStaff: 2 },
+  { name: 'Modular Cutter', type: 'modular_cutter', mass: 50, cost: 14, techLevel: 9, serviceStaff: 2 },
+  { name: 'Light Fighter', type: 'light_fighter', mass: 30, cost: 36, techLevel: 9, serviceStaff: 1 },
+  { name: 'Medium Fighter', type: 'medium_fighter', mass: 60, cost: 80, techLevel: 10, serviceStaff: 2 },
+  { name: 'Heavy Fighter', type: 'heavy_fighter', mass: 90, cost: 124, techLevel: 12, serviceStaff: 3 }
 ];
+
+// Swappable modules for the Modular Cutter — see ModularCutterModule in
+// types/ship.ts and calculateModularCutterBayMass() below for the tonnage
+// mechanic that governs how many of these a design can actually carry.
+export const MODULE_TYPES = [
+  { name: 'Sensor Module', type: 'sensor_module', mass: 30, cost: 40, description: 'Optical, radio/magnetic, and mass sensors.' },
+  { name: 'Fuel Module', type: 'fuel_module', mass: 30, cost: 3, description: '29.5 tons of fuel in a .5 ton bladder.' },
+  { name: 'Residence Module', type: 'residence_module', mass: 30, cost: 30, description: 'Reconfigurable up to 7 cabins, 3 smaller homes, or 2 large homes.' },
+  { name: 'Weapons Module', type: 'weapons_module', mass: 30, cost: 60, description: 'A selection of turrets (any laser, up to triple) and antipersonnel weapons with local power.' },
+  { name: 'Stealth Module', type: 'stealth_module', mass: 30, cost: 120, description: 'Advanced passive and active electromagnetic sensors, jammers, chaff, flares, and weasels (small mobile jammers with chaff and flares).' },
+  { name: 'Mining Module', type: 'mining_module', mass: 30, cost: 45, description: 'A mining laser and bulk processing machinery for asteroid mining and purification.' }
+];
+
+export function getModularCutterCount(vehicles: { vehicle_type: string; quantity: number }[]): number {
+  return vehicles
+    .filter(v => v.vehicle_type === 'modular_cutter')
+    .reduce((sum, v) => sum + v.quantity, 0);
+}
+
+// Each Modular Cutter's 50-ton hull already includes its one installed
+// module at no extra tonnage. Carrying any spares beyond that requires a
+// reload bay retrofit on every cutter at once (30 tons bay + 30 tons for
+// the first spare, per cutter = 60 tons/cutter); every spare beyond that
+// first one is a flat +30 tons with no further bay cost.
+export function calculateModularCutterBayMass(cutterCount: number, spareModuleCount: number): number {
+  if (cutterCount <= 0 || spareModuleCount <= 0) {
+    return 0;
+  }
+  return 60 * cutterCount + 30 * (spareModuleCount - 1);
+}
+
+export function calculateModularCutterModuleCost(modules: { module_type: string; quantity: number }[]): number {
+  return modules.reduce((sum, m) => {
+    const moduleType = MODULE_TYPES.find(mt => mt.type === m.module_type);
+    return sum + (moduleType ? moduleType.cost * m.quantity : 0);
+  }, 0);
+}
 
 export const DRONE_TYPES = [
   { name: 'War', type: 'war', mass: 10, cost: 2 },

--- a/src/services/antimatterIntegration.test.ts
+++ b/src/services/antimatterIntegration.test.ts
@@ -102,6 +102,7 @@ describe('Antimatter Integration Tests', () => {
     facilities: [],
     cargo: [],
     vehicles: [],
+    modular_cutter_modules: [],
     drones: []
   });
 

--- a/src/services/database.test.ts
+++ b/src/services/database.test.ts
@@ -28,6 +28,7 @@ describe('Database Service', () => {
     facilities: [],
     cargo: [],
     vehicles: [],
+    modular_cutter_modules: [],
     drones: []
   };
 

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -97,6 +97,7 @@ class DatabaseService {
         const ships = request.result.map((ship: StoredShipDesign) => ({
           ...ship,
           cargo: cleanInvalidCargo(ship.cargo),
+          modular_cutter_modules: ship.modular_cutter_modules || [],
           createdAt: new Date(ship.createdAt),
           updatedAt: new Date(ship.updatedAt)
         }));
@@ -121,6 +122,7 @@ class DatabaseService {
           resolve({
             ...ship,
             cargo: cleanInvalidCargo(ship.cargo),
+            modular_cutter_modules: ship.modular_cutter_modules || [],
             createdAt: new Date(ship.createdAt),
             updatedAt: new Date(ship.updatedAt)
           });
@@ -329,6 +331,7 @@ class DatabaseService {
           resolve({
             ...ship,
             cargo: cleanInvalidCargo(ship.cargo),
+            modular_cutter_modules: ship.modular_cutter_modules || [],
             createdAt: new Date(ship.createdAt),
             updatedAt: new Date(ship.updatedAt)
           });

--- a/src/services/flushDB.test.ts
+++ b/src/services/flushDB.test.ts
@@ -14,6 +14,7 @@ describe('Database Flush and Auto-reload', () => {
     facilities: [],
     cargo: [],
     vehicles: [],
+    modular_cutter_modules: [],
     drones: []
   };
 

--- a/src/services/initialDataService.test.ts
+++ b/src/services/initialDataService.test.ts
@@ -36,6 +36,7 @@ describe('Initial Data Service', () => {
     facilities: [],
     cargo: [],
     vehicles: [],
+    modular_cutter_modules: [],
     drones: []
   };
 

--- a/src/types/ship.ts
+++ b/src/types/ship.ts
@@ -71,10 +71,20 @@ export interface Cargo {
 
 export interface Vehicle {
   id?: number;
-  vehicle_type: 'honey_badger_off_roader' | 'atv_tracked' | 'atv_wheeled' | 'air_raft_truck' | 'open_top_air_raft' | 'fire_scorpion_walker' | 'socrates_field_car' | 'ufo_floating_home' | 'sealed_air_raft_4t' | 'iderati_afv' | 'aat_infantry_support' | 'sealed_air_raft_3t' | 'pug_armored_car' | 'exploration_gbike' | 'awesome_walker' | 'socrates_field_car_variant' | 'armored_fighting_vehicle' | 'fury_helicopter_gunship';
+  vehicle_type: 'honey_badger_off_roader' | 'atv_tracked' | 'atv_wheeled' | 'air_raft_truck' | 'open_top_air_raft' | 'fire_scorpion_walker' | 'socrates_field_car' | 'ufo_floating_home' | 'sealed_air_raft_4t' | 'iderati_afv' | 'aat_infantry_support' | 'sealed_air_raft_3t' | 'pug_armored_car' | 'exploration_gbike' | 'awesome_walker' | 'socrates_field_car_variant' | 'armored_fighting_vehicle' | 'fury_helicopter_gunship' | 'shuttle' | 'modular_cutter' | 'light_fighter' | 'medium_fighter' | 'heavy_fighter';
   quantity: number;
   mass: number;
   cost: number;
+}
+
+// Swappable 30-ton modules for the Modular Cutter. Tracked as a flat count
+// per type across every Modular Cutter on the design (not per individual
+// cutter) — see calculateModularCutterBayMass() in constants.ts for why the
+// extra bay tonnage can't be attributed to a single module entry.
+export interface ModularCutterModule {
+  id?: number;
+  module_type: 'sensor_module' | 'fuel_module' | 'residence_module' | 'weapons_module' | 'stealth_module' | 'mining_module';
+  quantity: number;
 }
 
 export interface Drone {
@@ -108,6 +118,7 @@ export interface ShipDesign {
   facilities: Facility[];
   cargo: Cargo[];
   vehicles: Vehicle[];
+  modular_cutter_modules: ModularCutterModule[];
   drones: Drone[];
 }
 

--- a/src/utils/printContent.test.ts
+++ b/src/utils/printContent.test.ts
@@ -35,6 +35,7 @@ const baseShip: ShipDesign = {
   facilities: [],
   cargo: [],
   vehicles: [],
+  modular_cutter_modules: [],
   drones: [],
 };
 

--- a/src/utils/printContent.ts
+++ b/src/utils/printContent.ts
@@ -7,7 +7,10 @@ import {
   VEHICLE_TYPES,
   DRONE_TYPES,
   BERTH_TYPES,
+  MODULE_TYPES,
   getHullCost,
+  getModularCutterCount,
+  calculateModularCutterBayMass,
 } from '../data/constants';
 
 function escapeHtml(text: string): string {
@@ -134,6 +137,22 @@ function buildTableRows(
     const display = vehicle.quantity === 1 ? name : `${name} (x${vehicle.quantity})`;
     rows.push(row(i === 0 ? 'Vehicles' : '', display, vehicle.mass * vehicle.quantity, vehicle.cost * vehicle.quantity));
   });
+
+  // Modular Cutter spare modules + reload bay
+  const modularCutterModules = shipDesign.modular_cutter_modules || [];
+  const modularCutterCount = getModularCutterCount(shipDesign.vehicles);
+  const spareModuleCount = modularCutterModules.reduce((sum, m) => sum + m.quantity, 0);
+  const moduleBayMass = calculateModularCutterBayMass(modularCutterCount, spareModuleCount);
+  const moduleBayOverheadMass = moduleBayMass - spareModuleCount * 30;
+  modularCutterModules.filter(m => m.quantity > 0).forEach(module => {
+    const moduleType = MODULE_TYPES.find(mt => mt.type === module.module_type);
+    const name = moduleType?.name || module.module_type;
+    const display = module.quantity === 1 ? name : `${name} (x${module.quantity})`;
+    rows.push(row('', display, module.quantity * 30, (moduleType?.cost ?? 0) * module.quantity));
+  });
+  if (moduleBayOverheadMass > 0) {
+    rows.push(row('', 'Modular Cutter Reload Bay', moduleBayOverheadMass, 0));
+  }
 
   // Drones
   shipDesign.drones.filter(d => d.quantity > 0).forEach((drone, i) => {


### PR DESCRIPTION
## Summary
- Ports the vehicles/modules feature already merged on the `megastructure` branch (commit `4e7c3d3`) onto `main`, adapted to main's file structure and UI conventions (jump-drive logic untouched — this is purely a Vehicles panel feature).
- Adds five vehicle types: Shuttle (90t, 12 MCr), Modular Cutter (50t, 14 MCr), Light Fighter (30t, 36 MCr), Medium Fighter (60t, 80 MCr), Heavy Fighter (90t, 124 MCr).
- Adds a Modular Cutter module bay system: each cutter's hull already includes one free module; carrying spares requires a reload-bay retrofit across every cutter at once (60 tons/cutter for the first spare, +30 tons/spare after that — see `calculateModularCutterBayMass()`). Six 30-ton module types are available (Sensor 40 MCr, Fuel 3 MCr, Residence 30 MCr, Weapons 60 MCr, Stealth 120 MCr, Mining 45 MCr); the bay itself has no MCr cost.
- Wires module bay mass / module cost into `App.tsx`'s mass and cost calculations, `MassSidebar.tsx`, `SummaryPanel.tsx` (table + CSV), and `printContent.ts`.
- `VehiclesPanel.tsx` gets a new "Modular Cutter Modules" section (shown only when at least one Modular Cutter is selected), following main's existing +/- button and summary-table UI pattern rather than megastructure's quantity-input pattern.
- Backward compatibility for ships saved before this change: `modular_cutter_modules: ship.modular_cutter_modules || []` added in `database.ts`'s `getAllShips`/`getShipById`/`getShipByName`, mirroring the existing `cleanInvalidCargo()` fallback pattern (main has no per-field `|| []` reconstruction in App.tsx like megastructure does, so the DB layer is the single choke point for all load paths).
- Added unit tests for `getModularCutterCount`, `calculateModularCutterBayMass`, and `calculateModularCutterModuleCost` in `constants.test.ts` (mirroring the reference implementation's test cases), and updated every hand-built `ShipDesign`/`StoredShipDesign` test fixture with the new field.

## Notes
- Tech levels and service staff counts for the five new vehicles are assumed from the reference implementation (not specified by the original requester) — easy to adjust if the SRD numbers should differ.
- Manual browser verification was not performed (no Chrome access in this environment). `pnpm exec tsc -b`, `pnpm lint`, and `pnpm test:run` all pass (382 tests, 25 suites).

## Test plan
- [x] `pnpm exec tsc -b` — no type errors
- [x] `pnpm lint` — clean
- [x] `pnpm test:run` — all passing (382/382), including new `calculateModularCutterBayMass`/`calculateModularCutterModuleCost` tests
- [ ] Manual browser check of the new Vehicles panel module UI (not performed — no Chrome access here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfP6mdpd7rwyAAZsYjobER