### PR TITLE
Add vehicle-driven pilot/gunner/engineer crew requirements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, lazy, Suspense } from 'react';
 import type { Ship, ShipDesign, MassCalculation, CostCalculation, StaffRequirements } from './types/ship';
-import { calculateTotalFuelMass, calculateVehicleServiceStaff, calculateDroneServiceStaff, calculateMedicalStaff, convertTechLevelToNumber, getBridgeMassAndCost, getEffectiveMaxJump, getHullCost, getNumberOfSections, getMinimumComputer, getRoboticsCrewDivisor, getRoboticsGunnerDivisor, COMPUTER_TYPES, VEHICLE_TYPES, WEAPON_TYPES, BAY_WEAPON_TYPES, getAvailableSpinalWeapons, getModularCutterCount, calculateModularCutterBayMass, calculateModularCutterModuleCost } from './data/constants';
+import { calculateTotalFuelMass, calculateVehicleServiceStaff, calculateVehicleCrewStaff, calculateDroneServiceStaff, calculateMedicalStaff, convertTechLevelToNumber, getBridgeMassAndCost, getEffectiveMaxJump, getHullCost, getNumberOfSections, getMinimumComputer, getRoboticsCrewDivisor, getRoboticsGunnerDivisor, COMPUTER_TYPES, VEHICLE_TYPES, WEAPON_TYPES, BAY_WEAPON_TYPES, getAvailableSpinalWeapons, getModularCutterCount, calculateModularCutterBayMass, calculateModularCutterModuleCost } from './data/constants';
 import { databaseService } from './services/database';
 import { logger } from './utils/logger';
 import { createEmptyShipDesign, createDefaultShip } from './utils/shipDefaults';
@@ -207,6 +207,11 @@ function App() {
     // same rate as engineers above; we only track the (reduced) human count.
     const service = Math.ceil(baseService / roboticsDivisor);
 
+    // Crew that rides along with fighters/shuttles/military vehicles
+    // (pilots, gunners, engineers) — separate from the maintenance-focused
+    // vehicleService above, and not reduced by Robotics.
+    const vehicleCrew = calculateVehicleCrewStaff(shipDesign.vehicles);
+
     const totalStaterooms = shipDesign.berths
       .filter(berth => berth.berth_type === 'staterooms' || berth.berth_type === 'luxury_staterooms')
       .reduce((sum, berth) => sum + berth.quantity, 0);
@@ -222,10 +227,10 @@ function App() {
     // the corresponding position; infantry/armor/mp/security have no
     // baseline formula elsewhere, so they're purely custom-crew-driven.
     const customCrew = shipDesign.custom_crew;
-    const pilotTotal = pilot + customCrew.pilot;
+    const pilotTotal = pilot + vehicleCrew.pilot + customCrew.pilot;
     const navigatorTotal = navigator + customCrew.navigator;
-    const engineersTotal = engineers + customCrew.engineers;
-    const gunnersTotal = gunners + customCrew.gunners;
+    const engineersTotal = engineers + vehicleCrew.engineer + customCrew.engineers;
+    const gunnersTotal = gunners + vehicleCrew.gunner + customCrew.gunners;
     const serviceTotal = service + customCrew.service;
     const stewardsTotal = stewards + customCrew.stewards;
     const nurses = baseNurses + customCrew.nurses;

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -779,6 +779,61 @@ export function calculateVehicleServiceStaff(vehicles: { vehicle_type: string; q
   return totalServiceStaff;
 }
 
+// Names (not types) of vehicles that count as "military vehicles" for the
+// pilot/gunner crew add-on below. Matched by prefix, not exact type, so a
+// future variant sharing the same name lineage (e.g. an "Iderati Mk II")
+// picks up the same crew requirement automatically.
+const MILITARY_VEHICLE_NAME_PREFIXES = [
+  'Iderati',
+  'Armored Fighting Vehicle',
+  'Fire Scorpion',
+  'Awesome AWS-8Q',
+  'Fury Helicopter Gunship',
+  '22 ton AAT'
+];
+
+// Crew that rides along with combat/utility vehicles, on top of the
+// maintenance-focused calculateVehicleServiceStaff above:
+// - Fighters (Light/Medium/Heavy) each need a pilot; Medium and Heavy also
+//   need a gunner; Heavy additionally needs an engineer.
+// - Each Shuttle needs a pilot.
+// - Each military vehicle (matched by name prefix) needs a pilot, plus a
+//   gunner if over 5 tons, or two gunners if over 30 tons.
+export function calculateVehicleCrewStaff(
+  vehicles: { vehicle_type: string; quantity: number }[]
+): { pilot: number; gunner: number; engineer: number } {
+  let pilot = 0;
+  let gunner = 0;
+  let engineer = 0;
+
+  for (const vehicle of vehicles) {
+    const vehicleType = VEHICLE_TYPES.find(vt => vt.type === vehicle.vehicle_type);
+    if (!vehicleType) continue;
+    const qty = vehicle.quantity;
+
+    if (vehicleType.type === 'light_fighter' || vehicleType.type === 'medium_fighter' || vehicleType.type === 'heavy_fighter') {
+      pilot += qty;
+      if (vehicleType.type === 'medium_fighter' || vehicleType.type === 'heavy_fighter') {
+        gunner += qty;
+      }
+      if (vehicleType.type === 'heavy_fighter') {
+        engineer += qty;
+      }
+    } else if (vehicleType.type === 'shuttle') {
+      pilot += qty;
+    } else if (MILITARY_VEHICLE_NAME_PREFIXES.some(prefix => vehicleType.name.startsWith(prefix))) {
+      pilot += qty;
+      if (vehicleType.mass > 30) {
+        gunner += qty * 2;
+      } else if (vehicleType.mass > 5) {
+        gunner += qty;
+      }
+    }
+  }
+
+  return { pilot, gunner, engineer };
+}
+
 export function calculateDroneServiceStaff(drones: { drone_type: string; quantity: number }[]): number {
   let heavyDroneTonnage = 0; // 10 ton drones
   let lightDroneTonnage = 0; // less than 10 ton drones

--- a/src/services/vehicleCrewStaff.test.ts
+++ b/src/services/vehicleCrewStaff.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from '@jest/globals';
+import { calculateVehicleCrewStaff } from '../data/constants';
+
+describe('Vehicle Crew Staff Calculations', () => {
+  it('should require no crew for 0 vehicles', () => {
+    const vehicles: { vehicle_type: string; quantity: number }[] = [];
+    expect(calculateVehicleCrewStaff(vehicles)).toEqual({ pilot: 0, gunner: 0, engineer: 0 });
+  });
+
+  it('should require no crew add-on for a non-combat vehicle', () => {
+    const vehicles = [{ vehicle_type: 'honey_badger_off_roader', quantity: 3 }];
+    expect(calculateVehicleCrewStaff(vehicles)).toEqual({ pilot: 0, gunner: 0, engineer: 0 });
+  });
+
+  describe('Fighters', () => {
+    it('Light Fighter: 1 pilot per unit, no gunner or engineer', () => {
+      const vehicles = [{ vehicle_type: 'light_fighter', quantity: 2 }];
+      expect(calculateVehicleCrewStaff(vehicles)).toEqual({ pilot: 2, gunner: 0, engineer: 0 });
+    });
+
+    it('Medium Fighter: 1 pilot and 1 gunner per unit, no engineer', () => {
+      const vehicles = [{ vehicle_type: 'medium_fighter', quantity: 3 }];
+      expect(calculateVehicleCrewStaff(vehicles)).toEqual({ pilot: 3, gunner: 3, engineer: 0 });
+    });
+
+    it('Heavy Fighter: 1 pilot, 1 gunner, and 1 engineer per unit', () => {
+      const vehicles = [{ vehicle_type: 'heavy_fighter', quantity: 2 }];
+      expect(calculateVehicleCrewStaff(vehicles)).toEqual({ pilot: 2, gunner: 2, engineer: 2 });
+    });
+
+    it('mixed fighter squadron sums correctly', () => {
+      const vehicles = [
+        { vehicle_type: 'light_fighter', quantity: 2 },
+        { vehicle_type: 'medium_fighter', quantity: 1 },
+        { vehicle_type: 'heavy_fighter', quantity: 1 }
+      ];
+      // pilots: 2 + 1 + 1 = 4; gunners: 1 (medium) + 1 (heavy) = 2; engineers: 1 (heavy)
+      expect(calculateVehicleCrewStaff(vehicles)).toEqual({ pilot: 4, gunner: 2, engineer: 1 });
+    });
+  });
+
+  describe('Shuttles', () => {
+    it('1 pilot per shuttle, no gunner or engineer', () => {
+      const vehicles = [{ vehicle_type: 'shuttle', quantity: 4 }];
+      expect(calculateVehicleCrewStaff(vehicles)).toEqual({ pilot: 4, gunner: 0, engineer: 0 });
+    });
+
+    it('Modular Cutter is not a shuttle and gets no crew add-on', () => {
+      const vehicles = [{ vehicle_type: 'modular_cutter', quantity: 2 }];
+      expect(calculateVehicleCrewStaff(vehicles)).toEqual({ pilot: 0, gunner: 0, engineer: 0 });
+    });
+  });
+
+  describe('Military vehicles', () => {
+    it('Iderati AFV (10 tons): 1 pilot + 1 gunner per unit (>5, not >30)', () => {
+      const vehicles = [{ vehicle_type: 'iderati_afv', quantity: 2 }];
+      expect(calculateVehicleCrewStaff(vehicles)).toEqual({ pilot: 2, gunner: 2, engineer: 0 });
+    });
+
+    it('Armored Fighting Vehicle (10 tons): 1 pilot + 1 gunner per unit', () => {
+      const vehicles = [{ vehicle_type: 'armored_fighting_vehicle', quantity: 1 }];
+      expect(calculateVehicleCrewStaff(vehicles)).toEqual({ pilot: 1, gunner: 1, engineer: 0 });
+    });
+
+    it('Fire Scorpion Quad Walker (65 tons): 1 pilot + 2 gunners per unit (>30)', () => {
+      const vehicles = [{ vehicle_type: 'fire_scorpion_walker', quantity: 1 }];
+      expect(calculateVehicleCrewStaff(vehicles)).toEqual({ pilot: 1, gunner: 2, engineer: 0 });
+    });
+
+    it('Awesome AWS-8Q Walker (80 tons): 1 pilot + 2 gunners per unit (>30)', () => {
+      const vehicles = [{ vehicle_type: 'awesome_walker', quantity: 1 }];
+      expect(calculateVehicleCrewStaff(vehicles)).toEqual({ pilot: 1, gunner: 2, engineer: 0 });
+    });
+
+    it('Fury Helicopter Gunship (8 tons): 1 pilot + 1 gunner per unit (>5, not >30)', () => {
+      const vehicles = [{ vehicle_type: 'fury_helicopter_gunship', quantity: 1 }];
+      expect(calculateVehicleCrewStaff(vehicles)).toEqual({ pilot: 1, gunner: 1, engineer: 0 });
+    });
+
+    it('22 ton AAT Infantry Support Vehicle (22 tons): 1 pilot + 1 gunner per unit', () => {
+      const vehicles = [{ vehicle_type: 'aat_infantry_support', quantity: 1 }];
+      expect(calculateVehicleCrewStaff(vehicles)).toEqual({ pilot: 1, gunner: 1, engineer: 0 });
+    });
+
+    it('quantities multiply through correctly', () => {
+      const vehicles = [{ vehicle_type: 'fire_scorpion_walker', quantity: 3 }];
+      expect(calculateVehicleCrewStaff(vehicles)).toEqual({ pilot: 3, gunner: 6, engineer: 0 });
+    });
+  });
+
+  it('mixed scenario across fighters, shuttles, and military vehicles', () => {
+    const vehicles = [
+      { vehicle_type: 'heavy_fighter', quantity: 1 },       // pilot 1, gunner 1, engineer 1
+      { vehicle_type: 'shuttle', quantity: 2 },              // pilot 2
+      { vehicle_type: 'iderati_afv', quantity: 1 },           // pilot 1, gunner 1
+      { vehicle_type: 'fire_scorpion_walker', quantity: 1 },  // pilot 1, gunner 2
+      { vehicle_type: 'honey_badger_off_roader', quantity: 5 } // nothing
+    ];
+    expect(calculateVehicleCrewStaff(vehicles)).toEqual({ pilot: 5, gunner: 4, engineer: 1 });
+  });
+});


### PR DESCRIPTION
## Summary
- Fighters (Light/Medium/Heavy) now each add a pilot; Medium and Heavy also add a gunner; Heavy also adds an engineer.
- Each Shuttle adds a pilot.
- Named military vehicles (Iderati, Armored Fighting Vehicle, Fire Scorpion, Awesome AWS-8Q, Fury Helicopter Gunship, 22 ton AAT) add a pilot, plus a gunner once over 5 tons, or two gunners once over 30 tons.
- Implemented as `calculateVehicleCrewStaff()` in `src/data/constants.ts`, wired into `calculateStaffRequirements()` in `App.tsx` alongside the existing maintenance-focused `calculateVehicleServiceStaff()`. Not affected by the Robotics divisor (crew that flies/gunners a vehicle isn't automated the way ship-support staff is), same treatment as the companion PRs below.

Companion PRs: megastructure branch https://github.com/DavidLDawes/aid/pull/264, main branch https://github.com/DavidLDawes/aid/pull/265

## Test plan
- [x] `pnpm test:run` — 254/254 passing, including 16 new tests in `src/services/vehicleCrewStaff.test.ts`
- [x] `tsc -b` clean
- [x] `pnpm lint` clean on changed files

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01KHikNhiu9s9tRYYU87oZ8S