### PR TITLE
Persist Rules Menu selections with the ship

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect, useCallback, lazy, Suspense } from 'react';
+import { useState, useEffect, useMemo, useCallback, lazy, Suspense } from 'react';
 import type { Ship, ShipDesign, MassCalculation, CostCalculation, StaffRequirements } from './types/ship';
-import { calculateTotalFuelMass, calculateVehicleServiceStaff, calculateVehicleCrewStaff, calculateDroneServiceStaff, calculateMedicalStaff, convertTechLevelToNumber, getBridgeMassAndCost, getEffectiveMaxJump, getHullCost, getNumberOfSections, getMinimumComputer, getRoboticsCrewDivisor, getRoboticsGunnerDivisor, COMPUTER_TYPES, VEHICLE_TYPES, WEAPON_TYPES, BAY_WEAPON_TYPES, getAvailableSpinalWeapons, getModularCutterCount, calculateModularCutterBayMass, calculateModularCutterModuleCost } from './data/constants';
+import { calculateTotalFuelMass, calculateVehicleServiceStaff, calculateVehicleCrewStaff, calculateDroneServiceStaff, calculateMedicalStaff, convertTechLevelToNumber, getBridgeMassAndCost, getEffectiveActiveRules, getEffectiveMaxJump, getHullCost, getNumberOfSections, getMinimumComputer, getRoboticsCrewDivisor, getRoboticsGunnerDivisor, isRuleAvailable, RULE_TECH_REQUIREMENTS, COMPUTER_TYPES, VEHICLE_TYPES, WEAPON_TYPES, BAY_WEAPON_TYPES, getAvailableSpinalWeapons, getModularCutterCount, calculateModularCutterBayMass, calculateModularCutterModuleCost } from './data/constants';
 import { databaseService } from './services/database';
 import { logger } from './utils/logger';
 import { createEmptyShipDesign, createDefaultShip } from './utils/shipDefaults';
@@ -39,9 +39,15 @@ function App() {
   const [currentPanel, setCurrentPanel] = useState(0);
   const [combinePilotNavigator, setCombinePilotNavigator] = useState(false);
   const [noStewards, setNoStewards] = useState(false);
-  const [activeRules, setActiveRules] = useState<Set<string>>(new Set(['spacecraft_design_srd']));
   const [shipDesign, setShipDesign] = useState<ShipDesign>(
     createEmptyShipDesign(createDefaultShip('', 'A', 5000, 'standard'))
+  );
+  // Derived (not stored) from shipDesign.active_rules so a save/load round
+  // trip can't desync "what the Rules Menu shows" from "what calculations
+  // apply" - see getEffectiveActiveRules.
+  const activeRules = useMemo(
+    () => getEffectiveActiveRules(shipDesign.active_rules ?? ['spacecraft_design_srd'], shipDesign.ship.tech_level),
+    [shipDesign.active_rules, shipDesign.ship.tech_level]
   );
 
   useEffect(() => {
@@ -337,14 +343,14 @@ function App() {
 
   const handleRuleChange = useCallback((ruleId: string, enabled: boolean) => {
     logger.info(`Rule "${ruleId}" ${enabled ? 'enabled' : 'disabled'}`);
-    setActiveRules(prevRules => {
-      const newRules = new Set(prevRules);
+    setShipDesign(prev => {
+      const requestedRules = new Set(prev.active_rules ?? ['spacecraft_design_srd']);
       if (enabled) {
-        newRules.add(ruleId);
+        requestedRules.add(ruleId);
       } else {
-        newRules.delete(ruleId);
+        requestedRules.delete(ruleId);
       }
-      return newRules;
+      return { ...prev, active_rules: Array.from(requestedRules) };
     });
   }, []);
 
@@ -511,19 +517,39 @@ function App() {
       !knownWeaponNames.has(weapon.weapon_name)
     );
 
+    // One-time migration for ships saved before active_rules existed: assume
+    // any TL-gated rule the ship's tech level could support was in effect
+    // when it was designed. Antimatter/Robotics only ever reduce calculated
+    // mass/crew, so defaulting them off instead would risk making an old,
+    // previously-valid design look overweight/wrong purely from this data
+    // migration - defaulting to "on wherever eligible" can't do that.
+    const needsRulesMigration = loadedShipDesign.active_rules === undefined;
+    const migratedActiveRules: string[] = needsRulesMigration
+      ? ['spacecraft_design_srd', ...Object.keys(RULE_TECH_REQUIREMENTS).filter(
+          ruleId => isRuleAvailable(ruleId, loadedShipDesign.ship.tech_level)
+        )]
+      : loadedShipDesign.active_rules ?? ['spacecraft_design_srd'];
+
     let cleanedShipDesign: ShipDesign = {
       ...loadedShipDesign,
-      modular_cutter_modules: loadedShipDesign.modular_cutter_modules || []
+      modular_cutter_modules: loadedShipDesign.modular_cutter_modules || [],
+      active_rules: migratedActiveRules
     };
 
     if (removedWeapons.length > 0) {
       logger.info(`Cleaned ${removedWeapons.length} non-standard weapons from "${loadedShipDesign.ship.name}"`);
       cleanedShipDesign = { ...cleanedShipDesign, weapons: standardWeapons };
+    }
 
+    if (needsRulesMigration) {
+      logger.info(`Migrated "${loadedShipDesign.ship.name}" to persisted Rules Menu selections: [${migratedActiveRules.join(', ')}]`);
+    }
+
+    if (removedWeapons.length > 0 || needsRulesMigration) {
       try {
         await databaseService.saveOrUpdateShipByName(cleanedShipDesign);
       } catch (error) {
-        logger.error('Error saving cleaned ship design', error);
+        logger.error('Error saving cleaned/migrated ship design', error);
       }
     }
 

--- a/src/components/RulesMenu.tsx
+++ b/src/components/RulesMenu.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { isTechLevelAtLeast } from '../data/constants';
+import { isRuleAvailable } from '../data/constants';
 import type { ShipDesign } from '../types/ship';
 import './RulesMenu.css';
 
@@ -18,78 +18,30 @@ interface RulesMenuProps {
 const RulesMenu: React.FC<RulesMenuProps> = ({ shipDesign, onRuleChange }) => {
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
-  
-  // Calculate tech level restrictions dynamically
+
   const currentTechLevel = shipDesign.ship.tech_level;
-  const canUseAntimatter = isTechLevelAtLeast(currentTechLevel, 'H');
-  const canUseLongerJumps = isTechLevelAtLeast(currentTechLevel, 'G');
-  const canUseRobotics = isTechLevelAtLeast(currentTechLevel, 'F');
+  const requestedRuleIds = new Set(shipDesign.active_rules ?? ['spacecraft_design_srd']);
 
-  const [enabledRuleIds, setEnabledRuleIds] = useState<Set<string>>(
-    new Set(['spacecraft_design_srd'])
-  );
+  const canUseAntimatter = isRuleAvailable('antimatter', currentTechLevel);
+  const canUseLongerJumps = isRuleAvailable('longer_jumps', currentTechLevel);
+  const canUseRobotics = isRuleAvailable('robotics', currentTechLevel);
 
-  // Keep a ref of the latest enabled ids so the tech-level effects below can
-  // see current state without re-running on every enable/disable click.
-  // Synced via effect (not during render) per react-hooks/refs.
-  const enabledRuleIdsRef = useRef(enabledRuleIds);
-  useEffect(() => {
-    enabledRuleIdsRef.current = enabledRuleIds;
-  }, [enabledRuleIds]);
-
-  // Tech-level constraints are computed inline for display (disabled/enabled
-  // below), but App's activeRules is a separate piece of state driven only by
-  // onRuleChange calls. A TL change can silently desync the two: dropping
-  // below the requirement must report the rule as disabled (or it keeps
-  // applying in App's calculations after the UI shows it off), and raising
-  // the TL back up must re-report it as enabled if the user still has it
-  // checked (or App never re-applies a rule the UI shows as on again).
-  // Skip the initial mount — there's nothing to reconcile until the tech
-  // level actually changes, and firing on mount would call onRuleChange for
-  // a rule the user never touched.
-  const isFirstAntimatterCheck = useRef(true);
-  useEffect(() => {
-    if (isFirstAntimatterCheck.current) {
-      isFirstAntimatterCheck.current = false;
-      return;
-    }
-    const antimatterEffective = enabledRuleIdsRef.current.has('antimatter') && canUseAntimatter;
-    onRuleChange?.('antimatter', antimatterEffective);
-  }, [canUseAntimatter, onRuleChange]);
-
-  const isFirstLongerJumpsCheck = useRef(true);
-  useEffect(() => {
-    if (isFirstLongerJumpsCheck.current) {
-      isFirstLongerJumpsCheck.current = false;
-      return;
-    }
-    const longerJumpsEffective = enabledRuleIdsRef.current.has('longer_jumps') && canUseLongerJumps;
-    onRuleChange?.('longer_jumps', longerJumpsEffective);
-  }, [canUseLongerJumps, onRuleChange]);
-
-  const isFirstRoboticsCheck = useRef(true);
-  useEffect(() => {
-    if (isFirstRoboticsCheck.current) {
-      isFirstRoboticsCheck.current = false;
-      return;
-    }
-    const roboticsEffective = enabledRuleIdsRef.current.has('robotics') && canUseRobotics;
-    onRuleChange?.('robotics', roboticsEffective);
-  }, [canUseRobotics, onRuleChange]);
-
-  // Derive full rule list each render; tech-level constraints are computed inline
-  // so no useEffect is needed to sync disabled state.
+  // Rule state is fully derived from shipDesign.active_rules (the user's
+  // persisted request) plus the current tech level, each render - there is
+  // no local/duplicated state to keep in sync, so a tech-level change or a
+  // ship load can't desync what this menu shows from what App actually
+  // applies in calculations.
   const rules: RuleItem[] = [
     { id: 'spacecraft_design_srd', name: 'Spacecraft Design SRD', enabled: true, disabled: false },
     { id: 'high_guard_capital_ships', name: 'High Guard Capital Ship Design SRD', enabled: false, disabled: true },
     { id: 'antimatter', name: 'Antimatter',
-      enabled: enabledRuleIds.has('antimatter') && canUseAntimatter,
+      enabled: requestedRuleIds.has('antimatter') && canUseAntimatter,
       disabled: !canUseAntimatter },
     { id: 'longer_jumps', name: 'Longer Jumps',
-      enabled: enabledRuleIds.has('longer_jumps') && canUseLongerJumps,
+      enabled: requestedRuleIds.has('longer_jumps') && canUseLongerJumps,
       disabled: !canUseLongerJumps },
     { id: 'robotics', name: 'Robotics',
-      enabled: enabledRuleIds.has('robotics') && canUseRobotics,
+      enabled: requestedRuleIds.has('robotics') && canUseRobotics,
       disabled: !canUseRobotics },
   ];
 
@@ -100,17 +52,7 @@ const RulesMenu: React.FC<RulesMenuProps> = ({ shipDesign, onRuleChange }) => {
     // Don't allow disabling the Spacecraft Design SRD (it's always selected)
     if (ruleId === 'spacecraft_design_srd') return;
 
-    const newEnabled = !rule.enabled;
-    setEnabledRuleIds(prev => {
-      const next = new Set(prev);
-      if (newEnabled) next.add(ruleId);
-      else next.delete(ruleId);
-      return next;
-    });
-
-    if (onRuleChange) {
-      onRuleChange(ruleId, newEnabled);
-    }
+    onRuleChange?.(ruleId, !rule.enabled);
   };
 
   const getStatusIcon = (rule: RuleItem) => {
@@ -125,7 +67,7 @@ const RulesMenu: React.FC<RulesMenuProps> = ({ shipDesign, onRuleChange }) => {
       }
       return <span className="rule-status disabled">—</span>;
     }
-    return rule.enabled 
+    return rule.enabled
       ? <span className="rule-status enabled">✓</span>
       : <span className="rule-status disabled">✗</span>;
   };
@@ -163,7 +105,7 @@ const RulesMenu: React.FC<RulesMenuProps> = ({ shipDesign, onRuleChange }) => {
 
   return (
     <div className="rules-menu" ref={menuRef}>
-      <button 
+      <button
         className="rules-menu-button"
         onClick={() => setIsOpen(!isOpen)}
         aria-haspopup="true"
@@ -171,11 +113,11 @@ const RulesMenu: React.FC<RulesMenuProps> = ({ shipDesign, onRuleChange }) => {
       >
         Rules
       </button>
-      
+
       {isOpen && (
         <div className="rules-menu-dropdown">
           {rules.map(rule => (
-            <button 
+            <button
               key={rule.id}
               className={`rules-menu-item ${rule.disabled ? 'disabled' : ''} ${rule.enabled ? 'enabled' : ''}`}
               onClick={() => toggleRule(rule.id)}

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -39,6 +39,30 @@ export function isTechLevelAtLeast(currentLevel: string, requiredLevel: string):
   return currentIndex >= requiredIndex;
 }
 
+// Minimum tech level for each optional Rules Menu item that has one.
+// Rules absent from this map (e.g. 'spacecraft_design_srd') have no tech
+// requirement and are always available.
+export const RULE_TECH_REQUIREMENTS: Record<string, string> = {
+  antimatter: 'H',
+  longer_jumps: 'G',
+  robotics: 'F',
+};
+
+export function isRuleAvailable(ruleId: string, techLevel: string): boolean {
+  const required = RULE_TECH_REQUIREMENTS[ruleId];
+  return required === undefined || isTechLevelAtLeast(techLevel, required);
+}
+
+// A ship's `active_rules` records which rules the user has requested, so the
+// choice persists with the save file. The rules actually applied in
+// calculations are that request set filtered down to whatever the ship's
+// current tech level allows - so a rule that's TL-gated off (e.g. after
+// lowering tech level) stops affecting calculations immediately, without
+// losing the user's selection if they raise the tech level back up.
+export function getEffectiveActiveRules(requestedRuleIds: Iterable<string>, techLevel: string): Set<string> {
+  return new Set([...requestedRuleIds].filter(id => isRuleAvailable(id, techLevel)));
+}
+
 // Robotics (TL-F+, toggled via the Rules menu): robot workers assist each
 // engineer, letting them cover more of an engine's own crew requirement as
 // tech level improves. Divisor to apply (rounded up) to each engine's crew:

--- a/src/types/ship.ts
+++ b/src/types/ship.ts
@@ -155,6 +155,12 @@ export interface ShipDesign {
   drones: Drone[];
   custom_items: CustomItem[];
   custom_crew: CustomCrew;
+  // Rules Menu selections the user has requested for this ship (e.g.
+  // 'antimatter', 'longer_jumps', 'robotics'), persisted so a saved design's
+  // TL-gated calculations (fuel mass, jump caps, crew divisors) stay correct
+  // on reload. Optional for backward compatibility with ships saved before
+  // this field existed - treat a missing value as ['spacecraft_design_srd'].
+  active_rules?: string[];
 }
 
 export interface MassCalculation {

--- a/src/utils/shipDefaults.ts
+++ b/src/utils/shipDefaults.ts
@@ -38,7 +38,8 @@ export const createEmptyShipDesign = (shipInfo: Ship): ShipDesign => {
     modular_cutter_modules: [],
     drones: [],
     custom_items: [],
-    custom_crew: createEmptyCustomCrew()
+    custom_crew: createEmptyCustomCrew(),
+    active_rules: ['spacecraft_design_srd']
   };
 };
 


### PR DESCRIPTION
## Summary
- `activeRules` (Antimatter/Longer Jumps/Robotics) lived only in App session state, disconnected from the saved ship, so loading a different ship never reset it — a rule enabled on one ship kept applying to a later, lower-tech-level ship even though the Rules Menu showed it as unavailable.
- Moved `active_rules` onto `ShipDesign` and derive the effective (tech-level-gated) set from it each render via `getEffectiveActiveRules`, so there's no separate state that can go stale. `RulesMenu` is now a fully controlled component with no local rule state.
- Ships saved before this field existed are migrated once on load: any rule their tech level could support is assumed on (Antimatter/Robotics only ever reduce mass/crew, so this can't turn a previously-valid design into an apparent overweight one), and the migrated result is persisted back to the DB.

## Test plan
- [x] `pnpm build` (tsc -b) passes with no errors
- [x] `pnpm test:run` — full suite (254 tests) passes, including `RulesMenu.test.tsx` unchanged
- [ ] Manual: load a pre-existing ship saved before this change and confirm Rules Menu reflects TL-eligible rules as on, mass/crew unchanged from before
- [ ] Manual: toggle a rule, save, reload, confirm it's still applied
- [ ] Manual: lower tech level below a rule's requirement, confirm it stops applying immediately but re-applies if TL is raised back

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GqYxdY6w6qrmNsoZPoUnM