### PR TITLE
Persist Rules Menu selections on the ship design, not App state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import type { Ship, ShipDesign, MassCalculation, CostCalculation, StaffRequirements } from './types/ship';
-import { calculateTotalFuelMass, calculateVehicleServiceStaff, calculateVehicleCrewStaff, calculateDroneServiceStaff, calculateMedicalStaff, convertTechLevelToNumber, getBridgeMassAndCost, getHullCost, getMaxJumpByTechLevel, VEHICLE_TYPES, WEAPON_TYPES, getModularCutterCount, calculateModularCutterBayMass, calculateModularCutterModuleCost } from './data/constants';
+import { calculateTotalFuelMass, calculateVehicleServiceStaff, calculateVehicleCrewStaff, calculateDroneServiceStaff, calculateMedicalStaff, convertTechLevelToNumber, getBridgeMassAndCost, getEffectiveActiveRules, getHullCost, getMaxJumpByTechLevel, isRuleAvailable, RULE_TECH_REQUIREMENTS, VEHICLE_TYPES, WEAPON_TYPES, getModularCutterCount, calculateModularCutterBayMass, calculateModularCutterModuleCost } from './data/constants';
 import { databaseService } from './services/database';
 import { generateShipPrintContent } from './utils/printContent';
 import { logger } from './utils/logger';
@@ -41,7 +41,8 @@ const EMPTY_SHIP_DESIGN: ShipDesign = {
   cargo: [],
   vehicles: [],
   modular_cutter_modules: [],
-  drones: []
+  drones: [],
+  active_rules: ['spacecraft_design_srd']
 };
 
 function App() {
@@ -50,8 +51,14 @@ function App() {
   const [combinePilotNavigator, setCombinePilotNavigator] = useState(false);
   const [noStewards, setNoStewards] = useState(false);
   const [noEngineer, setNoEngineer] = useState(false);
-  const [activeRules, setActiveRules] = useState<Set<string>>(new Set(['spacecraft_design_srd']));
   const [shipDesign, setShipDesign] = useState<ShipDesign>(EMPTY_SHIP_DESIGN);
+  // Derived (not stored) from shipDesign.active_rules so a save/load round
+  // trip can't desync "what the Rules Menu shows" from "what calculations
+  // apply" - see getEffectiveActiveRules.
+  const activeRules = useMemo(
+    () => getEffectiveActiveRules(shipDesign.active_rules ?? ['spacecraft_design_srd'], shipDesign.ship.tech_level),
+    [shipDesign.active_rules, shipDesign.ship.tech_level]
+  );
 
   const checkExistingShips = async () => {
     logger.info('Initializing database');
@@ -253,14 +260,14 @@ function App() {
 
   const handleRuleChange = useCallback((ruleId: string, enabled: boolean) => {
     logger.info(`Rule "${ruleId}" ${enabled ? 'enabled' : 'disabled'}`);
-    setActiveRules(prevRules => {
-      const newRules = new Set(prevRules);
+    setShipDesign(prev => {
+      const requestedRules = new Set(prev.active_rules ?? ['spacecraft_design_srd']);
       if (enabled) {
-        newRules.add(ruleId);
+        requestedRules.add(ruleId);
       } else {
-        newRules.delete(ruleId);
+        requestedRules.delete(ruleId);
       }
-      return newRules;
+      return { ...prev, active_rules: Array.from(requestedRules) };
     });
 
     // Disabling Longer Jumps invalidates jump drives above the base tech level cap
@@ -402,19 +409,39 @@ function App() {
       !knownWeaponNames.includes(weapon.weapon_name)
     );
 
-    let cleanedShipDesign = loadedShipDesign;
+    // One-time migration for ships saved before active_rules existed: assume
+    // any TL-gated rule the ship's tech level could support was in effect
+    // when it was designed. Antimatter/Longer Jumps only ever reduce
+    // calculated mass or raise a cap, so defaulting them off instead would
+    // risk making an old, previously-valid design look overweight or newly
+    // invalid purely from this data migration - defaulting to "on wherever
+    // eligible" can't do that.
+    const needsRulesMigration = loadedShipDesign.active_rules === undefined;
+    const migratedActiveRules: string[] = needsRulesMigration
+      ? ['spacecraft_design_srd', ...Object.keys(RULE_TECH_REQUIREMENTS).filter(
+          ruleId => isRuleAvailable(ruleId, loadedShipDesign.ship.tech_level)
+        )]
+      : loadedShipDesign.active_rules ?? ['spacecraft_design_srd'];
+
+    let cleanedShipDesign: ShipDesign = {
+      ...loadedShipDesign,
+      active_rules: migratedActiveRules
+    };
 
     if (removedWeapons.length > 0) {
       logger.info(`Removed ${removedWeapons.length} non-standard weapon(s) from "${loadedShipDesign.ship.name}"`);
-      cleanedShipDesign = {
-        ...loadedShipDesign,
-        weapons: standardWeapons
-      };
+      cleanedShipDesign = { ...cleanedShipDesign, weapons: standardWeapons };
+    }
 
+    if (needsRulesMigration) {
+      logger.info(`Migrated "${loadedShipDesign.ship.name}" to persisted Rules Menu selections: [${migratedActiveRules.join(', ')}]`);
+    }
+
+    if (removedWeapons.length > 0 || needsRulesMigration) {
       try {
         await databaseService.saveOrUpdateShipByName(cleanedShipDesign);
       } catch (error) {
-        logger.error(`Failed to save cleaned ship design for "${loadedShipDesign.ship.name}"`, error);
+        logger.error(`Failed to save cleaned/migrated ship design for "${loadedShipDesign.ship.name}"`, error);
       }
     }
 

--- a/src/components/RulesMenu.tsx
+++ b/src/components/RulesMenu.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { isTechLevelAtLeast } from '../data/constants';
+import { isRuleAvailable } from '../data/constants';
 import type { ShipDesign } from '../types/ship';
 import './RulesMenu.css';
 
@@ -18,80 +18,28 @@ interface RulesMenuProps {
 const RulesMenu: React.FC<RulesMenuProps> = ({ shipDesign, onRuleChange }) => {
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
-  
-  // Calculate tech level restrictions dynamically
+
   const currentTechLevel = shipDesign.ship.tech_level;
-  const canUseAntimatter = isTechLevelAtLeast(currentTechLevel, 'H');
-  const canUseLongerJumps = isTechLevelAtLeast(currentTechLevel, 'G');
-  
-  const [rules, setRules] = useState<RuleItem[]>([
-    {
-      id: 'spacecraft_design_srd',
-      name: 'Spacecraft Design SRD',
-      enabled: true,
-      disabled: false
-    },
-    {
-      id: 'high_guard_capital_ships',
-      name: 'High Guard Capital Ship Design SRD',
-      enabled: false,
-      disabled: true // greyed out and can't be selected
-    },
-    {
-      id: 'antimatter',
-      name: 'Antimatter',
-      enabled: false,
-      disabled: !canUseAntimatter
-    },
-    {
-      id: 'longer_jumps',
-      name: 'Longer Jumps',
-      enabled: false,
-      disabled: !canUseLongerJumps
-    }
-  ]);
-  
-  // Keep a ref of the latest rules so the tech-level effect can see current
-  // enabled states without re-running on every rules update. Synced via its
-  // own effect (not during render) per react-hooks/refs.
-  const rulesRef = useRef(rules);
-  useEffect(() => {
-    rulesRef.current = rules;
-  }, [rules]);
+  const requestedRuleIds = new Set(shipDesign.active_rules ?? ['spacecraft_design_srd']);
 
-  // Update rules when tech level changes. Rules that get force-disabled must
-  // also be reported upward, otherwise App's activeRules keeps applying them.
-  // Reconciling derived UI state (disabled/enabled) up to the parent on a
-  // dependency change is exactly what this effect is for, so the
-  // react-hooks/set-state-in-effect warning here is a false positive.
-  useEffect(() => {
-    const forceDisabled = rulesRef.current.filter(rule =>
-      rule.enabled && (
-        (rule.id === 'antimatter' && !canUseAntimatter) ||
-        (rule.id === 'longer_jumps' && !canUseLongerJumps)
-      )
-    );
+  const canUseAntimatter = isRuleAvailable('antimatter', currentTechLevel);
+  const canUseLongerJumps = isRuleAvailable('longer_jumps', currentTechLevel);
 
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setRules(prevRules => prevRules.map(rule => {
-      if (rule.id === 'antimatter') {
-        return {
-          ...rule,
-          disabled: !canUseAntimatter,
-          enabled: rule.enabled && canUseAntimatter // Turn off if no longer available
-        };
-      } else if (rule.id === 'longer_jumps') {
-        return {
-          ...rule,
-          disabled: !canUseLongerJumps,
-          enabled: rule.enabled && canUseLongerJumps // Turn off if no longer available
-        };
-      }
-      return rule;
-    }));
-
-    forceDisabled.forEach(rule => onRuleChange?.(rule.id, false));
-  }, [canUseAntimatter, canUseLongerJumps, onRuleChange]);
+  // Rule state is fully derived from shipDesign.active_rules (the user's
+  // persisted request) plus the current tech level, each render - there is
+  // no local/duplicated state to keep in sync, so a tech-level change or a
+  // ship load can't desync what this menu shows from what App actually
+  // applies in calculations.
+  const rules: RuleItem[] = [
+    { id: 'spacecraft_design_srd', name: 'Spacecraft Design SRD', enabled: true, disabled: false },
+    { id: 'high_guard_capital_ships', name: 'High Guard Capital Ship Design SRD', enabled: false, disabled: true },
+    { id: 'antimatter', name: 'Antimatter',
+      enabled: requestedRuleIds.has('antimatter') && canUseAntimatter,
+      disabled: !canUseAntimatter },
+    { id: 'longer_jumps', name: 'Longer Jumps',
+      enabled: requestedRuleIds.has('longer_jumps') && canUseLongerJumps,
+      disabled: !canUseLongerJumps }
+  ];
 
   const toggleRule = (ruleId: string) => {
     const rule = rules.find(r => r.id === ruleId);
@@ -100,17 +48,7 @@ const RulesMenu: React.FC<RulesMenuProps> = ({ shipDesign, onRuleChange }) => {
     // Don't allow disabling the Spacecraft Design SRD (it's always selected)
     if (ruleId === 'spacecraft_design_srd') return;
 
-    setRules(prevRules => 
-      prevRules.map(r => 
-        r.id === ruleId 
-          ? { ...r, enabled: !r.enabled }
-          : r
-      )
-    );
-
-    if (onRuleChange) {
-      onRuleChange(ruleId, !rule.enabled);
-    }
+    onRuleChange?.(ruleId, !rule.enabled);
   };
 
   const getStatusIcon = (rule: RuleItem) => {
@@ -123,7 +61,7 @@ const RulesMenu: React.FC<RulesMenuProps> = ({ shipDesign, onRuleChange }) => {
       }
       return <span className="rule-status disabled">—</span>;
     }
-    return rule.enabled 
+    return rule.enabled
       ? <span className="rule-status enabled">✓</span>
       : <span className="rule-status disabled">✗</span>;
   };
@@ -161,7 +99,7 @@ const RulesMenu: React.FC<RulesMenuProps> = ({ shipDesign, onRuleChange }) => {
 
   return (
     <div className="rules-menu" ref={menuRef}>
-      <button 
+      <button
         className="rules-menu-button"
         onClick={() => setIsOpen(!isOpen)}
         aria-haspopup="true"
@@ -169,11 +107,11 @@ const RulesMenu: React.FC<RulesMenuProps> = ({ shipDesign, onRuleChange }) => {
       >
         Rules
       </button>
-      
+
       {isOpen && (
         <div className="rules-menu-dropdown">
           {rules.map(rule => (
-            <button 
+            <button
               key={rule.id}
               className={`rules-menu-item ${rule.disabled ? 'disabled' : ''} ${rule.enabled ? 'enabled' : ''}`}
               onClick={() => toggleRule(rule.id)}

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -9,13 +9,36 @@ export function getTechLevelIndex(techLevel: string): number {
 export function isTechLevelAtLeast(currentLevel: string, requiredLevel: string): boolean {
   const currentIndex = getTechLevelIndex(currentLevel);
   const requiredIndex = getTechLevelIndex(requiredLevel);
-  
+
   // If either tech level is invalid, return false
   if (currentIndex === -1 || requiredIndex === -1) {
     return false;
   }
-  
+
   return currentIndex >= requiredIndex;
+}
+
+// Minimum tech level for each optional Rules Menu item that has one. Rules
+// absent from this map (e.g. 'spacecraft_design_srd') have no tech
+// requirement and are always available.
+export const RULE_TECH_REQUIREMENTS: Record<string, string> = {
+  antimatter: 'H',
+  longer_jumps: 'G',
+};
+
+export function isRuleAvailable(ruleId: string, techLevel: string): boolean {
+  const required = RULE_TECH_REQUIREMENTS[ruleId];
+  return required === undefined || isTechLevelAtLeast(techLevel, required);
+}
+
+// A ship's `active_rules` records which rules the user has requested, so the
+// choice persists with the save file. The rules actually applied in
+// calculations are that request set filtered down to whatever the ship's
+// current tech level allows - so a rule that's TL-gated off (e.g. after
+// lowering tech level) stops affecting calculations immediately, without
+// losing the user's selection if they raise the tech level back up.
+export function getEffectiveActiveRules(requestedRuleIds: Iterable<string>, techLevel: string): Set<string> {
+  return new Set([...requestedRuleIds].filter(id => isRuleAvailable(id, techLevel)));
 }
 
 // Maximum jump performance by tech level: A=J1, B=J2 ... F+=J6.

--- a/src/types/ship.ts
+++ b/src/types/ship.ts
@@ -120,6 +120,12 @@ export interface ShipDesign {
   vehicles: Vehicle[];
   modular_cutter_modules: ModularCutterModule[];
   drones: Drone[];
+  // Rules Menu selections the user has requested for this ship (e.g.
+  // 'antimatter', 'longer_jumps'), persisted so a saved design's TL-gated
+  // calculations (fuel mass, jump caps) stay correct on reload. Optional for
+  // backward compatibility with ships saved before this field existed —
+  // treat a missing value as ['spacecraft_design_srd'].
+  active_rules?: string[];
 }
 
 export interface MassCalculation {


### PR DESCRIPTION
## Summary

Ports the `capital`-branch fix for stale Rules Menu state (PR #270, commit 5c6e7a2) to `main`.

- The Rules Menu (Antimatter, Longer Jumps) tracked which rules were active in a `useState<Set<string>>` on `App`, completely disconnected from the saved ship. Loading a different ship (or changing tech level) never reset it, so a rule enabled for one ship kept silently applying to mass/jump-cap calculations for another, even though the Rules Menu UI correctly showed it as unavailable.
- Naively resetting rules on every load was also wrong: a ship legitimately designed with an eligible rule (e.g. Antimatter's fuel savings) would lose that effect on reload, making its saved mass look different purely because of *when* it was loaded.

### Fix
- `src/types/ship.ts`: add optional `ShipDesign.active_rules?: string[]` — the user's requested rule ids, round-tripping through save/load for free. Defaults to `['spacecraft_design_srd']`.
- `src/data/constants.ts`: add `RULE_TECH_REQUIREMENTS` (`antimatter: 'H'`, `longer_jumps: 'G'` — main only has these two TL-gated rules, no Robotics here), `isRuleAvailable(ruleId, techLevel)`, and `getEffectiveActiveRules(requestedRuleIds, techLevel)`, which filters the requested set down to what's currently tech-eligible.
- `src/App.tsx`: removed the standalone `activeRules` state; it's now a `useMemo` derived from `shipDesign.active_rules` + `shipDesign.ship.tech_level`. `handleRuleChange` now writes into `shipDesign.active_rules` via the normal `setShipDesign` setter instead of a separate one.
- `src/components/RulesMenu.tsx`: removed all local `useState`/`useRef`/reconciliation `useEffect`s that tried to keep local "enabled" state in sync with tech-level changes. It's now a fully controlled component — reads requested rule ids from the `shipDesign` prop and computes enabled/disabled inline every render.
- `src/App.tsx` `handleLoadShip`: one-time migration for ships saved before `active_rules` existed — seeds `[spacecraft_design_srd, ...every TL-gated rule the ship's saved tech level supports]` rather than defaulting to off, since both rules only ever reduce mass or raise a jump cap (never add mass), so this can't make an old valid design newly overweight. Persisted back to DB once, following the same pattern already used for stripping non-standard weapons on load.

### Notable adaptations from the capital-branch reference
- `main` has no Robotics rule and no `shipDefaults.ts`/`createEmptyShipDesign` helper — the empty-ship-design object lives inline in `App.tsx` as `EMPTY_SHIP_DESIGN`, updated directly.
- Only two TL-gated rules exist here (`antimatter` @ TL-H, `longer_jumps` @ TL-G), vs. three on `capital`.
- `RulesMenu.test.tsx` needed no changes — its assertions were already written against props/rendered output, not the component's now-removed internal state, so the controlled-component rewrite is a drop-in behavioral match.

## Test plan
- [x] `pnpm build` (`tsc -b && vite build`) — succeeds
- [x] `node_modules/.bin/jest.cmd --no-coverage --watchAll=false` — 26 suites / 419 tests, all pass (includes `RulesMenu.test.tsx` unmodified)
- [x] `pnpm lint` — only 2 pre-existing errors in unrelated `.js` files, unchanged by this diff

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016GqYxdY6w6qrmNsoZPoUnM