### PR TITLE
Persist Rules Menu selections on the design instead of App state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, lazy, Suspense } from 'react';
+import { useState, useEffect, useMemo, useCallback, lazy, Suspense } from 'react';
 import type { ShipDesign, MassCalculation, CostCalculation, StaffRequirements } from './types/ship';
 import {
   calculateVehicleServiceStaff, calculateDroneServiceStaff, calculateVehicleCrewStaff,
@@ -8,6 +8,7 @@ import {
   getMegastructureSections, PLANT_PER_SCOOP,
   hasAntimatterPlant, calculateAntimatterAdjustedManeuverFuel,
   getRoboticsSupportDivisor, getMinPowerPlantForFuelEquipment,
+  getEffectiveActiveRules, isRuleAvailable, RULE_TECH_REQUIREMENTS,
   getModularCutterCount, calculateModularCutterBayMass, calculateModularCutterModuleCost
 } from './data/constants';
 import { databaseService } from './services/database';
@@ -51,9 +52,15 @@ const panels = [
 function App() {
   const [showSelectShip, setShowSelectShip] = useState(true);
   const [currentPanel, setCurrentPanel] = useState(0);
-  const [activeRules, setActiveRules] = useState<Set<string>>(new Set(['spacecraft_design_srd']));
   const [shipDesign, setShipDesign] = useState<ShipDesign>(
     createEmptyShipDesign(createDefaultShip('', 'A', 1_000_000, 'standard'))
+  );
+  // Derived (not stored) from shipDesign.active_rules so a save/load round
+  // trip can't desync "what the Rules Menu shows" from "what calculations
+  // apply" - see getEffectiveActiveRules.
+  const activeRules = useMemo(
+    () => getEffectiveActiveRules(shipDesign.active_rules ?? ['spacecraft_design_srd'], shipDesign.ship.tech_level),
+    [shipDesign.active_rules, shipDesign.ship.tech_level]
   );
 
   useEffect(() => {
@@ -330,10 +337,10 @@ function App() {
 
   const handleRuleChange = useCallback((ruleId: string, enabled: boolean) => {
     logger.info(`Rule "${ruleId}" ${enabled ? 'enabled' : 'disabled'}`);
-    setActiveRules(prevRules => {
-      const newRules = new Set(prevRules);
-      if (enabled) { newRules.add(ruleId); } else { newRules.delete(ruleId); }
-      return newRules;
+    setShipDesign(prev => {
+      const requestedRules = new Set(prev.active_rules ?? ['spacecraft_design_srd']);
+      if (enabled) { requestedRules.add(ruleId); } else { requestedRules.delete(ruleId); }
+      return { ...prev, active_rules: Array.from(requestedRules) };
     });
   }, []);
 
@@ -459,20 +466,44 @@ function App() {
       !knownWeaponNames.has(weapon.weapon_name)
     );
 
+    // One-time migration for designs saved before active_rules existed:
+    // assume any TL-gated rule the design's tech level could support was in
+    // effect when it was designed. Robotics only ever reduces calculated
+    // crew (engineer/gunner/service/steward divisors), so defaulting it off
+    // instead would risk making an old, previously-valid design look
+    // overstaffed purely from this data migration - defaulting to "on
+    // wherever eligible" can't do that. Antimatter has no effect on any
+    // calculation on this branch (see Rules System in CLAUDE.md), so its
+    // migrated value is inert either way.
+    const needsRulesMigration = loadedShipDesign.active_rules === undefined;
+    const migratedActiveRules: string[] = needsRulesMigration
+      ? ['spacecraft_design_srd', ...Object.keys(RULE_TECH_REQUIREMENTS).filter(
+          ruleId => isRuleAvailable(ruleId, loadedShipDesign.ship.tech_level)
+        )]
+      : loadedShipDesign.active_rules ?? ['spacecraft_design_srd'];
+
     let cleanedShipDesign: ShipDesign = {
       ...loadedShipDesign,
       fuel_systems: loadedShipDesign.fuel_systems || [],
       zone_sections: loadedShipDesign.zone_sections || [],
-      modular_cutter_modules: loadedShipDesign.modular_cutter_modules || []
+      modular_cutter_modules: loadedShipDesign.modular_cutter_modules || [],
+      active_rules: migratedActiveRules
     };
 
     if (removedWeapons.length > 0) {
       logger.info(`Cleaned ${removedWeapons.length} non-standard weapons`);
       cleanedShipDesign = { ...cleanedShipDesign, weapons: standardWeapons };
+    }
+
+    if (needsRulesMigration) {
+      logger.info(`Migrated "${loadedShipDesign.ship.name}" to persisted Rules Menu selections: [${migratedActiveRules.join(', ')}]`);
+    }
+
+    if (removedWeapons.length > 0 || needsRulesMigration) {
       try {
         await databaseService.saveOrUpdateShipByName(cleanedShipDesign);
       } catch (error) {
-        logger.error('Error saving cleaned design', error);
+        logger.error('Error saving cleaned/migrated design', error);
       }
     }
 

--- a/src/components/RulesMenu.tsx
+++ b/src/components/RulesMenu.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { isTechLevelAtLeast } from '../data/constants';
+import { isRuleAvailable } from '../data/constants';
 import type { ShipDesign } from '../types/ship';
 import './RulesMenu.css';
 
@@ -19,25 +19,25 @@ const RulesMenu: React.FC<RulesMenuProps> = ({ shipDesign, onRuleChange }) => {
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   
-  // Calculate tech level restrictions dynamically
   const currentTechLevel = shipDesign.ship.tech_level;
-  const canUseAntimatter = isTechLevelAtLeast(currentTechLevel, 'H');
-  const canUseRobotics = isTechLevelAtLeast(currentTechLevel, 'F');
+  const requestedRuleIds = new Set(shipDesign.active_rules ?? ['spacecraft_design_srd']);
 
-  const [enabledRuleIds, setEnabledRuleIds] = useState<Set<string>>(
-    new Set(['spacecraft_design_srd'])
-  );
+  const canUseAntimatter = isRuleAvailable('antimatter', currentTechLevel);
+  const canUseRobotics = isRuleAvailable('robotics', currentTechLevel);
 
-  // Derive full rule list each render; tech-level constraints are computed inline
-  // so no useEffect is needed to sync disabled state.
+  // Rule state is fully derived from shipDesign.active_rules (the user's
+  // persisted request) plus the current tech level, each render - there is
+  // no local/duplicated state to keep in sync, so a tech-level change or a
+  // design load can't desync what this menu shows from what App actually
+  // applies in calculations.
   const rules: RuleItem[] = [
     { id: 'spacecraft_design_srd', name: 'Spacecraft Design SRD', enabled: true, disabled: false },
     { id: 'high_guard_capital_ships', name: 'High Guard Capital Ship Design SRD', enabled: false, disabled: true },
     { id: 'antimatter', name: 'Antimatter',
-      enabled: enabledRuleIds.has('antimatter') && canUseAntimatter,
+      enabled: requestedRuleIds.has('antimatter') && canUseAntimatter,
       disabled: !canUseAntimatter },
     { id: 'robotics', name: 'Robotics',
-      enabled: enabledRuleIds.has('robotics') && canUseRobotics,
+      enabled: requestedRuleIds.has('robotics') && canUseRobotics,
       disabled: !canUseRobotics },
   ];
 
@@ -48,17 +48,7 @@ const RulesMenu: React.FC<RulesMenuProps> = ({ shipDesign, onRuleChange }) => {
     // Don't allow disabling the Spacecraft Design SRD (it's always selected)
     if (ruleId === 'spacecraft_design_srd') return;
 
-    const newEnabled = !rule.enabled;
-    setEnabledRuleIds(prev => {
-      const next = new Set(prev);
-      if (newEnabled) next.add(ruleId);
-      else next.delete(ruleId);
-      return next;
-    });
-
-    if (onRuleChange) {
-      onRuleChange(ruleId, newEnabled);
-    }
+    onRuleChange?.(ruleId, !rule.enabled);
   };
 
   const getStatusIcon = (rule: RuleItem) => {

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -39,6 +39,29 @@ export function isTechLevelAtLeast(currentLevel: string, requiredLevel: string):
   return currentIndex >= requiredIndex;
 }
 
+// Minimum tech level for each optional Rules Menu item that has one.
+// Rules absent from this map (e.g. 'spacecraft_design_srd') have no tech
+// requirement and are always available.
+export const RULE_TECH_REQUIREMENTS: Record<string, string> = {
+  antimatter: 'H',
+  robotics: 'F',
+};
+
+export function isRuleAvailable(ruleId: string, techLevel: string): boolean {
+  const required = RULE_TECH_REQUIREMENTS[ruleId];
+  return required === undefined || isTechLevelAtLeast(techLevel, required);
+}
+
+// A design's `active_rules` records which rules the user has requested, so
+// the choice persists with the save file. The rules actually applied in
+// calculations are that request set filtered down to whatever the design's
+// current tech level allows - so a rule that's TL-gated off (e.g. after
+// lowering tech level) stops affecting calculations immediately, without
+// losing the user's selection if they raise the tech level back up.
+export function getEffectiveActiveRules(requestedRuleIds: Iterable<string>, techLevel: string): Set<string> {
+  return new Set([...requestedRuleIds].filter(id => isRuleAvailable(id, techLevel)));
+}
+
 // Maximum power plant performance by tech level. Megastructures have no
 // jump drive, so power plant tiers are gated directly by TL: TL-H unlocks
 // the P-10 an Antimatter Plant requires, TL-J extends further to P-12.

--- a/src/types/ship.ts
+++ b/src/types/ship.ts
@@ -173,6 +173,13 @@ export interface ShipDesign {
   custom_crew: CustomCrew;
   fuel_systems: FuelSystem[];
   zone_sections: ZoneSection[];
+  // Rules Menu selections the user has requested for this megastructure
+  // (e.g. 'antimatter', 'robotics'), persisted so a saved design's
+  // TL-gated calculations (Robotics' engineer/gunner/service/steward
+  // divisors) stay correct on reload. Optional for backward compatibility
+  // with designs saved before this field existed - treat a missing value
+  // as ['spacecraft_design_srd'].
+  active_rules?: string[];
 }
 
 export interface MassCalculation {

--- a/src/utils/shipDefaults.ts
+++ b/src/utils/shipDefaults.ts
@@ -40,7 +40,8 @@ export const createEmptyShipDesign = (shipInfo: Ship): ShipDesign => {
     custom_items: [],
     custom_crew: createEmptyCustomCrew(),
     fuel_systems: [],
-    zone_sections: []
+    zone_sections: [],
+    active_rules: ['spacecraft_design_srd']
   };
 };
 


### PR DESCRIPTION
## Summary

Mirrors the fix already applied on `capital` (PR #270), adapted to this branch's actual rules.

The Rules Menu's active rules (`antimatter`, `robotics`) were tracked as React state local to `App`, completely disconnected from the saved `ShipDesign`. This caused two related bugs:

1. **Stale rule application**: loading a different design (or one at a lower tech level) never reset this App-level state, so Robotics' engineer/gunner/service/steward crew-divisor reduction kept being applied to a newly loaded/created design even though the Rules Menu UI correctly showed the toggle as unavailable for that design's actual tech level.
2. **The naive fix (reset on load) would have been wrong too**: a design legitimately built with Robotics active would silently lose that effect on reload, making its saved crew requirements look wrong purely because of *when* it was loaded, not because anything about the design changed.

## Changes

- **`src/types/ship.ts`**: added optional `ShipDesign.active_rules?: string[]`, recording which rules the user has requested for this design. Round-trips through IndexedDB automatically (no schema change needed).
- **`src/utils/shipDefaults.ts`**: `createEmptyShipDesign()` now defaults `active_rules` to `['spacecraft_design_srd']`.
- **`src/data/constants.ts`**: added `RULE_TECH_REQUIREMENTS` (`antimatter: 'H'`, `robotics: 'F'`), `isRuleAvailable(ruleId, techLevel)`, and `getEffectiveActiveRules(requestedRuleIds, techLevel)` — the latter derives the actually-applied rule set fresh every time from the requested set + current tech level, so a rule stops applying the instant tech level drops below its requirement and resumes automatically if raised back up, without losing the user's original selection.
- **`src/App.tsx`**: removed the `activeRules` `useState`; replaced with a `useMemo` derived from `shipDesign.active_rules ?? ['spacecraft_design_srd']` and the design's tech level via `getEffectiveActiveRules`. `handleRuleChange` now updates `shipDesign.active_rules` through the normal design setter (so it persists via save/load) instead of a separate setter.
- **`src/components/RulesMenu.tsx`**: now a fully controlled component — deleted the local `enabledRuleIds` state; checked/disabled status is computed inline each render straight from the `shipDesign` prop and the current tech level. No `useEffect` reconciliation needed (there was none to remove beyond the local state — this branch didn't even have capital's stopgap tech-level-sync effects, so the desync was arguably worse here).
- **`src/App.tsx` `handleLoadShip`**: one-time migration for designs saved before `active_rules` existed — seeds `[spacecraft_design_srd, ...every TL-gated rule the design's saved tech level supports]`, on the assumption it was in effect when designed, then persists it back (same pattern already used there for stripping non-standard weapons). This is safe because Robotics only ever *reduces* crew requirements; Antimatter has no effect on any calculation on this branch at all (per CLAUDE.md's Rules System notes), so its migrated value is inert either way.

## Notable adaptations from the `capital` reference

- This branch has no jump drive and thus no "Longer Jumps" rule — only `antimatter` (TL-H) and `robotics` (TL-F) are TL-gated here.
- `antimatter` on this branch doesn't affect any calculation (the actual Antimatter Plant mechanic is driven by `hasAntimatterPlant(fuel_systems)` instead, unrelated to the Rules Menu toggle) — migrating it "on wherever eligible" is harmless either way since it's inert, but it's included in `RULE_TECH_REQUIREMENTS` for consistency and in case it's wired up to something later.
- This branch's `RulesMenu.tsx` had no useEffect-based tech-level reconciliation at all (unlike capital's pre-fix version), so removing local state also simplifies it more than the equivalent capital diff did.

## Test plan

- [x] `pnpm build` (tsc -b + vite build) — passes with no errors
- [x] `pnpm test:run` — 275 tests, 17 suites, all pass unchanged (`RulesMenu.test.tsx` needed no updates — the controlled component is behaviorally equivalent for user-facing toggle behavior)
- [x] `pnpm lint` — clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016GqYxdY6w6qrmNsoZPoUnM